### PR TITLE
Rename `Mapping` to `Stub` terminology in WireMock context

### DIFF
--- a/mokksy/src/main/kotlin/me/kpavlov/mokksy/BuildingStep.kt
+++ b/mokksy/src/main/kotlin/me/kpavlov/mokksy/BuildingStep.kt
@@ -9,11 +9,11 @@ import io.ktor.sse.ServerSentEvent
  * and their respective responses.
  *
  * @param R The type of the request specification.
- * @property mappings A mutable collection of mappings that associate request specifications with response definitions.
+ * @property stubs A mutable collection of mappings that associate request specifications with response definitions.
  * @property requestSpecification The request specification currently being processed.
  */
 public open class BuildingStep<R : RequestSpecification> internal constructor(
-    private val mappings: MutableCollection<Mapping<*>>,
+    private val stubs: MutableCollection<Stub<*>>,
     protected val requestSpecification: R,
 ) {
     /**
@@ -26,12 +26,12 @@ public open class BuildingStep<R : RequestSpecification> internal constructor(
      */
     public open infix fun <T> respondsWith(block: ResponseDefinitionBuilder<T>.() -> Unit) {
         val responseDefinition = ResponseDefinitionBuilder<T>().apply(block).build()
-        val mapping =
-            Mapping(
+        val stub =
+            Stub(
                 requestSpecification,
                 responseDefinition,
             )
-        mappings += mapping
+        stubs += stub
     }
 
     /**
@@ -46,12 +46,12 @@ public open class BuildingStep<R : RequestSpecification> internal constructor(
         block: StreamingResponseDefinitionBuilder<T>.() -> Unit,
     ) {
         val responseDefinition = StreamingResponseDefinitionBuilder<T>().apply(block).build()
-        val mapping =
-            Mapping(
+        val stub =
+            Stub(
                 requestSpecification,
                 responseDefinition,
             )
-        mappings += mapping
+        stubs += stub
     }
 
     /**

--- a/mokksy/src/main/kotlin/me/kpavlov/mokksy/MokksyServer.kt
+++ b/mokksy/src/main/kotlin/me/kpavlov/mokksy/MokksyServer.kt
@@ -21,7 +21,7 @@ import io.ktor.server.routing.routing
 import io.ktor.server.sse.SSE
 import kotlinx.coroutines.runBlocking
 import org.slf4j.event.Level
-import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.ConcurrentSkipListSet
 
 @Suppress("TooManyFunctions")
 public open class MokksyServer(
@@ -48,14 +48,14 @@ public open class MokksyServer(
             routing {
                 route("{...}") {
                     handle {
-                        handleRequest(this@handle, this@embeddedServer, mappings)
+                        handleRequest(this@handle, this@embeddedServer, stubs)
                     }
                 }
             }
             configurer(this)
         }
 
-    private val mappings = ConcurrentLinkedQueue<Mapping<*>>()
+    private val stubs = ConcurrentSkipListSet<Stub<*>>()
 
     init {
         server.start(wait = wait)
@@ -93,7 +93,7 @@ public open class MokksyServer(
                 .method(equalityMatcher(httpMethod))
                 .build()
         return BuildingStep(
-            mappings = mappings,
+            stubs = stubs,
             requestSpecification = requestSpec,
         )
     }
@@ -188,7 +188,7 @@ public open class MokksyServer(
      * @return A list of unmatched request specifications.
      */
     public fun findAllUnmatchedRequests(): List<RequestSpecification> =
-        mappings
+        stubs
             .filter {
                 it.matchCount() == 0
             }.map { it.requestSpecification }
@@ -202,7 +202,7 @@ public open class MokksyServer(
      * testing scenarios.
      */
     public fun resetMatchCounts() {
-        mappings
+        stubs
             .forEach {
                 it.resetMatchCount()
             }

--- a/mokksy/src/main/kotlin/me/kpavlov/mokksy/RequestHandler.kt
+++ b/mokksy/src/main/kotlin/me/kpavlov/mokksy/RequestHandler.kt
@@ -14,25 +14,25 @@ import io.ktor.server.routing.RoutingContext
  *
  * @param context The routing context containing the request and response handlers.
  * @param application The Ktor application instance used for logging and other application-level operations.
- * @param mappings A collection of mappings that specify how incoming requests should be processed and responded to.
+ * @param stubs A collection of mappings that specify how incoming requests should be processed and responded to.
  */
 internal suspend fun handleRequest(
     context: RoutingContext,
     application: Application,
-    mappings: Collection<Mapping<*>>,
+    stubs: Collection<Stub<*>>,
 ) {
     val request = context.call.request
     application.log.info(
         "Request: ${request.httpMethod.value.uppercase()} ${request.uri}",
     )
-    val matchedMapping: Mapping<*>? =
-        mappings
+    val matchedStub: Stub<*>? =
+        stubs
             .filter {
                 it.requestSpecification.matches(request)
-            }.minWithOrNull(MappingComparator)
+            }.minWithOrNull(StubComparator)
 
-    if (matchedMapping != null) {
-        matchedMapping.apply {
+    if (matchedStub != null) {
+        matchedStub.apply {
             application.log.info(
                 "Request matched: {}",
                 requestSpecification.toDescription(),

--- a/mokksy/src/main/kotlin/me/kpavlov/mokksy/ResponseHandler.kt
+++ b/mokksy/src/main/kotlin/me/kpavlov/mokksy/ResponseHandler.kt
@@ -14,6 +14,15 @@ import io.ktor.sse.ServerSentEvent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
+/**
+ * Handles streaming responses for the specified `StreamResponseDefinition` and the given `ApplicationCall`.
+ * This method distinguishes between streaming response types, such as Server-Sent Events (SSE)
+ * and standard chunked data, to appropriately process and send the response to the client.
+ *
+ * @param T The type of the data being streamed in the response.
+ * @param responseDefinition Defines the streaming response, including the data chunks and content type.
+ * @param call The `ApplicationCall` instance associated with the current HTTP request.
+ */
 internal suspend fun <T> respondWithStream(
     responseDefinition: StreamResponseDefinition<T>,
     call: ApplicationCall,
@@ -53,6 +62,16 @@ internal suspend fun <T> respondWithStream(
     }
 }
 
+/**
+ * Sends a Server-Sent Events (SSE) stream response for the given request.
+ *
+ * The method uses the provided `SseStreamResponseDefinition` to determine the stream of
+ * Server-Sent Events (SSE) to send. It processes the SSE stream and sends events to the client
+ * immediately as they are collected.
+ *
+ * @param responseDefinition Defines the SSE stream response, including the flow of server-sent events to be sent.
+ * @param call The `ApplicationCall` representing the current HTTP request and response context.
+ */
 internal suspend fun respondWithSseStream(
     responseDefinition: SseStreamResponseDefinition,
     call: ApplicationCall,
@@ -67,6 +86,13 @@ internal suspend fun respondWithSseStream(
     processSSE(call, sseContent)
 }
 
+/**
+ * Handles a server-sent events (SSE) response by configuring the appropriate HTTP headers
+ * and sending the specified content to the client.
+ *
+ * @param call The [ApplicationCall] representing the current client-server interaction.
+ * @param content The [SSEServerContent] that represents the server-sent events to be delivered.
+ */
 @Suppress("unused")
 private suspend fun processSSE(
     call: ApplicationCall,

--- a/mokksy/src/main/kotlin/me/kpavlov/mokksy/Stub.kt
+++ b/mokksy/src/main/kotlin/me/kpavlov/mokksy/Stub.kt
@@ -6,18 +6,20 @@ import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Represents a mapping between an inbound request specification and an outbound response definition.
+ *
  * This class encapsulates the logic needed to handle HTTP requests and responses, including
  * matching request specifications, sending responses, and handling response data of various types.
+ * Resembles the [WireMock Stub](https://wiremock.org/docs/stubbing/) abstraction.
  *
  * @param T The type of the response data.
  * @property requestSpecification Defines the criteria used to match incoming requests.
  * @property responseDefinition Specifies the response to send for matched requests.
  */
-internal data class Mapping<T>(
+internal data class Stub<T>(
     val requestSpecification: RequestSpecification,
     val responseDefinition: AbstractResponseDefinition<T>,
-) : Comparable<Mapping<*>> {
-    override fun compareTo(other: Mapping<*>): Int = MappingComparator.compare(this, other)
+) : Comparable<Stub<*>> {
+    override fun compareTo(other: Stub<*>): Int = StubComparator.compare(this, other)
 
     private val matchCount = AtomicInteger(0)
 
@@ -60,17 +62,17 @@ internal data class Mapping<T>(
 }
 
 /**
- * Comparator implementation for `Mapping` objects.
+ * Comparator implementation for `Stub` objects.
  *
- * This comparator is used to compare `Mapping` instances based on the priority
+ * This comparator is used to compare `Stub` instances based on the priority
  * defined in their `requestSpecification`. Higher priority values are considered greater.
  *
- * Used internally for sorting or ordering `Mapping` objects when multiple mappings need
+ * Used internally for sorting or ordering `Stub` objects when multiple mappings need
  * to be evaluated or prioritized.
  */
-internal object MappingComparator : Comparator<Mapping<*>> {
+internal object StubComparator : Comparator<Stub<*>> {
     override fun compare(
-        o1: Mapping<*>,
-        o2: Mapping<*>,
+        o1: Stub<*>,
+        o2: Stub<*>,
     ): Int = o1.requestSpecification.priority().compareTo(o2.requestSpecification.priority())
 }

--- a/mokksy/src/test/kotlin/me/kpavlov/mokksy/StubComparatorTest.kt
+++ b/mokksy/src/test/kotlin/me/kpavlov/mokksy/StubComparatorTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 
-internal class MappingComparatorTest {
+internal class StubComparatorTest {
     lateinit var request1: RequestSpecification
     lateinit var request2: RequestSpecification
     lateinit var response: AbstractResponseDefinition<String>
@@ -23,10 +23,10 @@ internal class MappingComparatorTest {
         request1 = RequestSpecification(priority = 1)
         request2 = RequestSpecification(priority = 1)
 
-        val mapping1 = Mapping(request1, response)
-        val mapping2 = Mapping(request2, response)
+        val stub1 = Stub(request1, response)
+        val stub2 = Stub(request2, response)
 
-        val result = MappingComparator.compare(mapping1, mapping2)
+        val result = StubComparator.compare(stub1, stub2)
 
         assertThat(result).isZero()
     }
@@ -36,10 +36,10 @@ internal class MappingComparatorTest {
         request1 = RequestSpecification(priority = 1)
         request2 = RequestSpecification(priority = 2)
 
-        val mapping1 = Mapping(request1, response)
-        val mapping2 = Mapping(request2, response)
+        val stub1 = Stub(request1, response)
+        val stub2 = Stub(request2, response)
 
-        val result = MappingComparator.compare(mapping1, mapping2)
+        val result = StubComparator.compare(stub1, stub2)
 
         assertThat(result).isNegative()
     }
@@ -49,10 +49,10 @@ internal class MappingComparatorTest {
         request1 = RequestSpecification(priority = 2)
         request2 = RequestSpecification(priority = 1)
 
-        val mapping1 = Mapping(request1, response)
-        val mapping2 = Mapping(request2, response)
+        val stub1 = Stub(request1, response)
+        val stub2 = Stub(request2, response)
 
-        val result = MappingComparator.compare(mapping1, mapping2)
+        val result = StubComparator.compare(stub1, stub2)
 
         assertThat(result).isPositive()
     }


### PR DESCRIPTION


**Description:**

This pull request renames the `Mapping` class to `Stub` to align with the terminology used in WireMock for stubbing. All references, variables, and tests have been updated to accurately reflect this change. Additionally, `MappingComparator` has been renamed to `StubComparator`.

- Update class names and references
- Modify related variables
- Adjust test cases to reflect changes