### PR TITLE
Fix issue with failing to add Stub as duplicate. Refactor and enhance codebase

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,7 +24,8 @@ indent_size = 4
 [*.{kt,kts}]
 indent_size = 4
 max_line_length = 100
-ij_kotlin_name_count_to_use_star_import = 999
-ij_kotlin_name_count_to_use_star_import_for_members = 999
+ij_kotlin_name_count_to_use_star_import = 2147483647
+ij_kotlin_name_count_to_use_star_import_for_members = 2147483647
 ij_kotlin_packages_to_use_import_on_demand = unset
+ktlint_code_style = ktlint_official # intellij_idea or android_studio or ktlint_official (default)
 ktlint_function_naming_ignore_when_annotated_with = "Test"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,6 +22,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: main
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-##
+.PHONY: build test lint format all # always run
+
 build:
 	./gradlew clean build koverXmlReport
 
@@ -11,18 +12,18 @@ apidocs:
 	cp -R mokksy/build/dokka/html build/docs/api
 
 lint:prepare
-	  ktlint && \
-    mvn spotless:check
+	ktlint "!**/generated-sources/**" && \
+  ./gradlew detekt spotlessCheck
 
 # https://docs.openrewrite.org/recipes/maven/bestpractices
 format:prepare
-	  ktlint --format && \
-  	mvn spotless:apply && \
-	  mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
+	ktlint --format "!**/generated-sources/**" && \
+  ./gradlew spotlessApply && \
+	mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
 				-Drewrite.activeRecipes=org.openrewrite.maven.BestPractices \
 				-Drewrite.exportDatatables=true
 
 prepare:
-	  brew install ktlint --quiet
+	command -v ktlint >/dev/null 2>&1 || brew install ktlint --quiet
 
 all: format lint build

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/AbstractMockOpenaiTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/AbstractMockOpenaiTest.kt
@@ -4,9 +4,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import kotlin.random.Random
 
-internal abstract class AbstractMockOpenaiTest {
-    protected val openai = MockOpenai(verbose = true)
+val openai = MockOpenai(verbose = true)
 
+internal abstract class AbstractMockOpenaiTest {
     protected var temperature: Double = -1.0
     protected var seedValue: Int = -1
     protected var maxCompletionTokens: Long = -1

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/MockOpenaiTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/MockOpenaiTest.kt
@@ -3,13 +3,12 @@ package me.kpavlov.aimocks.openai
 import assertk.assertThat
 import assertk.assertions.hasValue
 import com.openai.core.JsonValue
-import com.openai.models.ChatCompletion
 import com.openai.models.ChatCompletionCreateParams
 import com.openai.models.ChatCompletionMessageParam
 import com.openai.models.ChatCompletionUserMessageParam
 import com.openai.models.ChatModel
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 
 internal class MockOpenaiTest : AbstractOpenaiTest() {
     @Test
@@ -46,7 +45,7 @@ internal class MockOpenaiTest : AbstractOpenaiTest() {
                         ),
                     ).model(ChatModel.GPT_4O_MINI)
                     .build()
-            val result: ChatCompletion =
+            val result =
                 client
                     .chat()
                     .completions()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     kotlin("multiplatform") version libs.versions.kotlin apply false
     kotlin("plugin.serialization") version libs.versions.kotlin apply false
     signing
+    id("com.diffplug.spotless") version "7.0.2"
 }
 
 allprojects {
@@ -32,6 +33,7 @@ subprojects {
     apply(plugin = "maven-publish")
     apply(plugin = "signing")
     apply(plugin = "org.jetbrains.dokka")
+    apply(plugin = "com.diffplug.spotless")
 
     // configure all format tasks at once
     tasks.withType<DokkaTaskPartial>().configureEach {
@@ -99,12 +101,30 @@ subprojects {
         )
         sign(publishing.publications["maven"])
     }
+
+    spotless {
+        kotlin {
+            ktlint()
+        }
+    }
 }
 
 dependencies {
     kover(project(":mokksy"))
     kover(project(":ai-mocks-core"))
     kover(project(":ai-mocks-openai"))
+}
+
+spotless {
+    ratchetFrom("origin/main")
+
+    kotlinGradle {
+        ktlint()
+    }
+    format("misc") {
+        target("*.md", ".gitignore")
+        trimTrailingWhitespace()
+    }
 }
 
 kover {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ dokka = "2.0.0"
 junitJupiter = "5.11.4"
 kotest = "5.9.1"
 kotlin = "2.1.10"
+mockk = "1.13.16"
 kotlinLogging = "7.0.4"
 kotlinx = "1.10.1"
 kover = "0.9.1"
@@ -44,6 +45,7 @@ langchain4j-kotlin = { group = "me.kpavlov.langchain4j.kotlin", name = "langchai
 langchain4j-openai = { group = "dev.langchain4j", name = "langchain4j-open-ai", version.ref = "langchain4j" }
 mockito = { group = "org.mockito", name = "mockito-junit-jupiter", version.ref = "mockito" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito-kotlin" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 netty = { group = "io.netty", name = "netty-handler", version.ref = "netty" }
 openai-java = { group = "com.openai", name = "openai-java", version.ref = "openai" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ netty = "4.1.118.Final"
 nexusPublish = "2.0.0"
 slf4j = "2.0.16"
 spring = "6.2.3"
-openai = "0.22.0"
+openai = "0.23.1"
 langchain4jKotlin = "0.1.8"
 langchain4j = "1.0.0-beta1"
 

--- a/mokksy/build.gradle.kts
+++ b/mokksy/build.gradle.kts
@@ -40,6 +40,7 @@ kotlin {
                 implementation(kotlin("test"))
                 implementation(libs.ktor.client.core)
                 implementation(libs.assertk)
+                implementation(libs.mockk)
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.mockito.kotlin)
                 implementation(libs.ktor.client.content.negotiation)

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/BuildingStep.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/BuildingStep.kt
@@ -31,7 +31,7 @@ public open class BuildingStep<R : RequestSpecification> internal constructor(
                 requestSpecification,
                 responseDefinition,
             )
-        stubs += stub
+        addStub(stub)
     }
 
     /**
@@ -51,7 +51,7 @@ public open class BuildingStep<R : RequestSpecification> internal constructor(
                 requestSpecification,
                 responseDefinition,
             )
-        stubs += stub
+        addStub(stub)
     }
 
     /**
@@ -67,4 +67,9 @@ public open class BuildingStep<R : RequestSpecification> internal constructor(
         respondsWithStream<ServerSentEvent>(
             block,
         )
+
+    private fun addStub(stub: Stub<*>) {
+        val added = stubs.add(stub)
+        assert(added) { "Duplicate stub detected: $stub" }
+    }
 }

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/HeaderMarchers.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/HeaderMarchers.kt
@@ -9,7 +9,7 @@ import io.ktor.http.Headers
 /**
  * Custom matcher to verify that the Ktor [Headers] object contains a header with the specified name and value.
  */
-internal fun haveHeader(
+internal fun containsHeader(
     name: String,
     value: String,
 ): Matcher<Headers> =
@@ -30,12 +30,12 @@ internal fun haveHeader(
  * Extension function for easier usage.
  */
 public infix fun Headers.shouldHaveHeader(header: Pair<String, String>) {
-    this should haveHeader(header.first, header.second)
+    this should containsHeader(header.first, header.second)
 }
 
 /**
  * Extension function to assert that the headers should not contain a specific header.
  */
 public infix fun Headers.shouldNotHaveHeader(header: Pair<String, String>) {
-    this shouldNot haveHeader(header.first, header.second)
+    this shouldNot containsHeader(header.first, header.second)
 }

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/RequestSpecification.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/RequestSpecification.kt
@@ -34,14 +34,14 @@ public const val DEFAULT_STUB_PRIORITY: Int = Int.MAX_VALUE
  * @property headers List of matchers for Ktor [Headers] object. All matchers must pass for a match to succeed.
  * @property body List of matchers for the request body as a string. All matchers must pass for a match to succeed.
  * @property priority The priority value used for comparing different specifications.
- * Lower values indicate higher priority.
+ * Lower values indicate higher priority. Default value is [DEFAULT_STUB_PRIORITY]
  */
 public open class RequestSpecification(
     public val method: Matcher<HttpMethod>? = null,
     public val path: Matcher<String>? = null,
     public val headers: List<Matcher<Headers>> = listOf(),
     public val body: List<Matcher<String>> = listOf(),
-    public val priority: Int?,
+    public val priority: Int? = DEFAULT_STUB_PRIORITY,
 ) {
     internal fun priority(): Int = priority ?: DEFAULT_STUB_PRIORITY
 
@@ -63,7 +63,7 @@ public open class RequestSpecification(
         bodyMatchers: List<Matcher<String>>,
         request: ApplicationRequest,
     ): Boolean {
-        val bodyString = request.call.receive(String::class)
+        val bodyString = request.call.receive(type = String::class)
         return bodyMatchers.all {
             it
                 .test(bodyString)

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/RequestSpecification.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/RequestSpecification.kt
@@ -118,7 +118,7 @@ public open class RequestSpecificationBuilder<B : RequestSpecificationBuilder<B>
         headerName: String,
         headerValue: String,
     ): RequestSpecificationBuilder<B> {
-        headers += haveHeader(headerName, headerValue)
+        headers += me.kpavlov.mokksy.containsHeader(headerName, headerValue)
         return this
     }
 

--- a/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/AbstractIT.kt
+++ b/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/AbstractIT.kt
@@ -5,16 +5,16 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import kotlin.random.Random
 
+val mokksy: MokksyServer =
+    MokksyServer(verbose = true) {
+        println("Running Mokksy server with ${it.engine} engine")
+    }
+
 internal abstract class AbstractIT(
     clientSupplier: (Int) -> HttpClient = {
         createKtorClient(it)
     },
 ) {
-    protected val mokksy: MokksyServer =
-        MokksyServer(verbose = true) {
-            println("Running server with ${it.engine} engine")
-        }
-
     protected val client: HttpClient = clientSupplier(mokksy.port())
 
     /**

--- a/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/RequestSpecificationTest.kt
+++ b/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/RequestSpecificationTest.kt
@@ -1,0 +1,126 @@
+package me.kpavlov.mokksy
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.equals.beEqual
+import io.kotest.matchers.string.contain
+import io.ktor.http.Headers
+import io.ktor.http.HttpMethod
+import io.ktor.server.request.ApplicationRequest
+import io.ktor.server.request.httpMethod
+import io.ktor.server.request.path
+import io.ktor.server.request.receive
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.Test
+
+@ExtendWith(MockKExtension::class)
+class RequestSpecificationTest {
+    @MockK
+    lateinit var request: ApplicationRequest
+
+    @Test
+    fun matches() =
+        runTest {
+            every { request.httpMethod } returns HttpMethod.Get
+            every { request.path() } returns "/test"
+            coEvery { request.call.receive(String::class) } returns "The body problem"
+            coEvery { request.headers } returns
+                Headers.build {
+                    append("X-Request-ID", "RequestID")
+                }
+            val headersMatcher = mockk<Matcher<Headers>>(relaxed = true)
+            every { headersMatcher.test(any()).passed() } returns true
+
+            val spec =
+                RequestSpecification(
+                    method = beEqual(HttpMethod.Get),
+                    path = contain("test"),
+                    headers = listOf(headersMatcher),
+                    body = listOf(contain("body")),
+                )
+
+            assertThat(spec.matches(request)).isTrue()
+        }
+
+    @Test
+    fun mismatchedMethod() =
+        runTest {
+            every { request.httpMethod } returns HttpMethod.Get
+            val spec =
+                RequestSpecification(
+                    method = beEqual(HttpMethod.Post),
+                    path = contain("test"),
+                )
+
+            assertThat(spec.matches(request)).isFalse()
+        }
+
+    @Test
+    fun mismatchedPath() =
+        runTest {
+            every { request.httpMethod } returns HttpMethod.Get
+            every { request.path() } returns "/test"
+
+            val spec =
+                RequestSpecification(
+                    method = beEqual(HttpMethod.Get),
+                    path = contain("differentPath"),
+                )
+
+            assertThat(spec.matches(request)).isFalse()
+        }
+
+    @Test
+    fun matchingHeaders() =
+        runTest {
+            every { request.httpMethod } returns HttpMethod.Get
+            every { request.path() } returns "/test"
+            coEvery { request.call.receive(String::class) } returns "The body problem"
+            coEvery { request.headers } returns
+                Headers.build {
+                    append("X-Request-ID", "RequestID")
+                }
+
+            val headersMatcher = mockk<Matcher<Headers>>(relaxed = true)
+            val spec = RequestSpecification(headers = listOf(headersMatcher))
+
+            every { headersMatcher.test(any()).passed() } returns true
+
+            assertThat(spec.matches(request)).isTrue()
+        }
+
+    @Test
+    fun mismatchedHeaders() =
+        runTest {
+            coEvery { request.headers } returns
+                Headers.build {
+                    append("X-Request-ID", "RequestID")
+                }
+
+            val headersMatcher = mockk<Matcher<Headers>>(relaxed = true)
+            val spec = RequestSpecification(headers = listOf(headersMatcher))
+
+            every { headersMatcher.test(any()).passed() } returns false
+
+            assertThat(spec.matches(request)).isFalse()
+        }
+
+    @Test
+    fun mismatchedBody() =
+        runTest {
+            coEvery { request.call.receive(String::class) } returns "Another body"
+
+            val bodyMatcher = contain("expectedBody")
+            val spec = RequestSpecification(body = listOf(bodyMatcher))
+
+            assertThat(spec.matches(request)).isFalse()
+        }
+}

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/MokksyIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/MokksyIT.kt
@@ -82,7 +82,7 @@ internal class MokksyIT : AbstractIT() {
             """.trimIndent()
         val configurer: RequestSpecificationBuilder<*>.() -> Unit = {
             path = beEqual("/method-$method")
-            containsHeader("X-Seed", "$seed")
+            this.containsHeader("X-Seed", "$seed")
         }
         block.invoke {
             configurer(this)
@@ -124,7 +124,7 @@ internal class MokksyIT : AbstractIT() {
             val uri = "/unmatched-headers"
             mokksy.get {
                 path = beEqual(uri)
-                containsHeader("Foo", "bar")
+                this.containsHeader("Foo", "bar")
             } respondsWith {
                 httpStatus = HttpStatusCode.OK
                 body = "Hello"

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/StubComparatorTest.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/StubComparatorTest.kt
@@ -19,7 +19,7 @@ internal class StubComparatorTest {
     }
 
     @Test
-    fun `compare should return zero when priorities are equal`() {
+    fun `compare should compare by creationOrder when priorities are equal`() {
         request1 = RequestSpecification(priority = 1)
         request2 = RequestSpecification(priority = 1)
 
@@ -28,7 +28,7 @@ internal class StubComparatorTest {
 
         val result = StubComparator.compare(stub1, stub2)
 
-        assertThat(result).isZero()
+        assertThat(result).isNegative()
     }
 
     @Test
@@ -55,5 +55,16 @@ internal class StubComparatorTest {
         val result = StubComparator.compare(stub1, stub2)
 
         assertThat(result).isPositive()
+    }
+
+    @Test
+    fun `compare should return zero when stubs are same`() {
+        request1 = RequestSpecification()
+
+        val stub1 = Stub(request1, response)
+
+        val result = StubComparator.compare(stub1, stub1)
+
+        assertThat(result).isZero()
     }
 }


### PR DESCRIPTION
### Description

This pull request introduces several improvements to the codebase, enhancing readability, consistency, and functionality:

- **Bugfix**
  - Fix issue with failing to add Stub as false-positive duplicate.

- **Refactoring**:
  - Test configurations have been streamlined by unifying parameter handling and ensuring consistent usage of variables.
  - The stub addition process has been updated to use a proper `addStub` method to detect duplicates.
  - Request logging has been enhanced to include detailed headers and body for improved debugging.

- **New Feature**:
  - Introduced `creationOrder` to the `Stub` class, ensuring consistent comparison when priorities are equal.

- **Testing**:
  - Comprehensive tests added for the `RequestSpecification` class to validate request matching logic (method, path, headers, body).
  - Adjustments to existing tests to validate new comparison and duplicate detection logic.

- **Code Quality**:
  - Integrated Spotless for consistent code formatting.
  - Renamed methods for better clarity (e.g., `haveHeader` to `containsHeader`).