### PR TITLE
Add handling for empty body matchers in RequestSpecification

### DIFF
--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/RequestSpecification.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/RequestSpecification.kt
@@ -63,6 +63,7 @@ public open class RequestSpecification(
         bodyMatchers: List<Matcher<String>>,
         request: ApplicationRequest,
     ): Boolean {
+        if (bodyMatchers.isEmpty()) return true
         val bodyString = request.call.receive(type = String::class)
         return bodyMatchers.all {
             it


### PR DESCRIPTION
This Pull Request introduces improvements to the request specification logic and enhances testing structure and clarity.
- Logic Update: Added a check in RequestSpecification to return true if bodyMatchers is empty.
- Test Structure Enhancement: Refactored RequestSpecificationTest with better-organized nested test classes for successful and failed matches.
