### PR TITLE
Support nullable and type-safe request payloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ lint:prepare
 
 # https://docs.openrewrite.org/recipes/maven/bestpractices
 format:prepare
-	ktlint --format "!**/generated-sources/**" && \
-  ./gradlew spotlessApply && \
+	./gradlew spotlessApply
 	./gradlew rewriteRun
+	ktlint --format "!**/generated-sources/**"
 
 prepare:
 	command -v ktlint >/dev/null 2>&1 || brew install ktlint --quiet

--- a/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/ChatRequestSpecification.kt
+++ b/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/ChatRequestSpecification.kt
@@ -7,7 +7,7 @@ public open class ChatRequestSpecification(
     public var temperature: Double? = null,
     public var maxCompletionTokens: Long? = null,
     public var model: String? = null,
-    public val requestBody: MutableList<Matcher<String>> = mutableListOf<Matcher<String>>(),
+    public val requestBody: MutableList<Matcher<String?>> = mutableListOf(),
 ) {
     public fun temperature(temperature: Double): ChatRequestSpecification =
         apply { this.temperature = temperature }

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/MockOpenai.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/MockOpenai.kt
@@ -20,30 +20,30 @@ public open class MockOpenai(
         block: OpenaiChatRequestSpecification.() -> Unit,
     ): OpenaiBuildingStep {
         val requestStep =
-            mokksy.post(name = name) {
+            mokksy.post<ChatCompletionRequest>(name = name) {
                 val chatRequest = OpenaiChatRequestSpecification()
                 block(chatRequest)
 
                 path = beEqual("/v1/chat/completions")
 
                 chatRequest.temperature?.let {
-                    body += containJsonKeyValue("temperature", it)
+                    bodyString += containJsonKeyValue("temperature", it)
                 }
 
                 chatRequest.maxCompletionTokens?.let {
-                    body += containJsonKeyValue("max_completion_tokens", it)
+                    bodyString += containJsonKeyValue("max_completion_tokens", it)
                 }
 
                 chatRequest.seed?.let {
-                    body += containJsonKeyValue("seed", it)
+                    bodyString += containJsonKeyValue("seed", it)
                 }
 
                 chatRequest.model?.let {
-                    body += containJsonKeyValue("model", it)
+                    bodyString += containJsonKeyValue("model", it)
                 }
 
                 chatRequest.requestBody.forEach {
-                    body += it
+                    bodyString += it
                 }
             }
 

--- a/mokksy/build.gradle.kts
+++ b/mokksy/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("multiplatform")
+    kotlin("plugin.serialization") apply true
     alias(libs.plugins.kover) apply true
 }
 

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/BuildingStep.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/BuildingStep.kt
@@ -8,15 +8,16 @@ import io.ktor.sse.ServerSentEvent
  * This class is part of a fluent API used to define mappings between request specifications
  * and their respective responses.
  *
+ * @param P The type of the request payload.
  * @param R The type of the request specification.
  * @param name An optional name assigned to the Stub for identification or debugging purposes.
  * @property stubs A mutable collection of mappings that associate request specifications with response definitions.
  * @property requestSpecification The request specification currently being processed.
  */
-public open class BuildingStep<R : RequestSpecification> internal constructor(
+public open class BuildingStep<P> internal constructor(
     private val name: String? = null,
     private val stubs: MutableCollection<Stub<*>>,
-    protected val requestSpecification: R,
+    protected val requestSpecification: RequestSpecification<P>,
 ) {
     /**
      * Associates the current request specification with a response definition.

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/MokksyServer.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/MokksyServer.kt
@@ -105,13 +105,13 @@ public open class MokksyServer(
      * @param block A lambda used to configure the `RequestSpecificationBuilder`.
      * @return A `BuildingStep` instance initialized with the generated request specification.
      */
-    public fun method(
+    public fun <P> method(
         name: String? = null,
         httpMethod: HttpMethod,
-        block: RequestSpecificationBuilder<*>.() -> Unit,
-    ): BuildingStep<RequestSpecification> {
+        block: RequestSpecificationBuilder<P?>.() -> Unit,
+    ): BuildingStep<P?> {
         val requestSpec =
-            RequestSpecificationBuilder()
+            RequestSpecificationBuilder<P?>()
                 .apply(block)
                 .method(equalityMatcher(httpMethod))
                 .build()
@@ -126,91 +126,168 @@ public open class MokksyServer(
      * Configures a HTTP GET request specification using the provided block and returns a `BuildingStep`
      * instance for further customization.
      *
+     * @param P type of the request payload
      * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
      * @return A `BuildingStep` instance initialized with the generated request specification.
      */
-    public fun get(
+    public fun <P : Any> get(
         name: String? = null,
-        block: RequestSpecificationBuilder<*>.() -> Unit,
-    ): BuildingStep<RequestSpecification> = method(name, Get, block)
+        block: RequestSpecificationBuilder<P?>.() -> Unit,
+    ): BuildingStep<P?> = method(name, Get, block)
+
+    /**
+     * Configures a HTTP GET request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun get(block: RequestSpecificationBuilder<Any?>.() -> Unit): BuildingStep<Any?> =
+        this.get(null, block)
 
     /**
      * Configures an HTTP POST request specification using the provided block and returns a `BuildingStep`
      * instance for further customization. This method utilizes the HTTP POST method to define the request
      * specification within the provided lambda.
      *
+     * @param P type of the request payload.
      * @param block A lambda used to configure the `RequestSpecificationBuilder` for the POST request.
      * @return A `BuildingStep` instance initialized with the generated request specification.
      */
-    public fun post(
+    public fun <P : Any> post(
         name: String? = null,
-        block: RequestSpecificationBuilder<*>.() -> Unit,
-    ): BuildingStep<RequestSpecification> = method(name, Post, block)
+        block: RequestSpecificationBuilder<P?>.() -> Unit,
+    ): BuildingStep<P?> = method(name, Post, block)
+
+    /**
+     * Configures a HTTP POST request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun post(block: RequestSpecificationBuilder<Any?>.() -> Unit): BuildingStep<Any?> =
+        this.post(null, block)
 
     /**
      * Configures an HTTP DELETE request specification using the provided block and returns a `BuildingStep`
      * instance for further customization. This method utilizes the HTTP DELETE method to define the request
      * specification within the provided lambda.
      *
+     * @param P type of the request payload.
      * @param block A lambda used to configure the `RequestSpecificationBuilder` for the DELETE request.
      * @return A `BuildingStep` instance initialized with the generated request specification.
      */
-    public fun delete(
+    public fun <P : Any> delete(
         name: String? = null,
-        block: RequestSpecificationBuilder<*>.() -> Unit,
-    ): BuildingStep<RequestSpecification> = method(name, Delete, block)
+        block: RequestSpecificationBuilder<P?>.() -> Unit,
+    ): BuildingStep<P?> = method(name, Delete, block)
+
+    /**
+     * Configures a HTTP DELETE request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun delete(block: RequestSpecificationBuilder<Any?>.() -> Unit): BuildingStep<Any?> =
+        this.delete(null, block)
 
     /**
      * Configures an HTTP PATCH request specification using the provided block and returns a `BuildingStep`
      * instance for further customization. This method uses the HTTP PATCH method to define the request
      * specification within the provided lambda.
      *
+     * @param P type of the request payload.
      * @param block A lambda used to configure the `RequestSpecificationBuilder` for the PATCH request.
      * @return A `BuildingStep` instance initialized with the generated request specification.
      */
-    public fun patch(
+    public fun <P : Any> patch(
         name: String? = null,
-        block: RequestSpecificationBuilder<*>.() -> Unit,
-    ): BuildingStep<RequestSpecification> = method(name, Patch, block)
+        block: RequestSpecificationBuilder<P?>.() -> Unit,
+    ): BuildingStep<P?> = method(name, Patch, block)
+
+    /**
+     * Configures a HTTP PATCH request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun patch(block: RequestSpecificationBuilder<Any?>.() -> Unit): BuildingStep<Any?> =
+        this.patch(null, block)
 
     /**
      * Configures an HTTP PUT request specification using the provided block and returns a `BuildingStep`
      * instance for further customization. This method utilizes the HTTP PUT method to define the request
      * specification within the provided lambda.
      *
+     * @param P type of the request payload
      * @param block A lambda used to configure the `RequestSpecificationBuilder` for the PUT request.
      * @return A `BuildingStep` instance initialized with the generated request specification.
      */
-    public fun put(
+    public fun <P : Any> put(
         name: String? = null,
-        block: RequestSpecificationBuilder<*>.() -> Unit,
-    ): BuildingStep<RequestSpecification> = method(name, Put, block)
+        block: RequestSpecificationBuilder<P?>.() -> Unit,
+    ): BuildingStep<P?> = method(name, Put, block)
+
+    /**
+     * Configures a HTTP PUT request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun put(block: RequestSpecificationBuilder<Any?>.() -> Unit): BuildingStep<Any?> =
+        this.put(null, block)
 
     /**
      * Configures an HTTP HEAD request specification using the provided block and returns a `BuildingStep`
      * instance for further customization. This method utilizes the HTTP HEAD method to define the request
      * specification within the provided lambda.
      *
+     * @param P type of the request payload
      * @param block A lambda used to configure the `RequestSpecificationBuilder` for the HEAD request.
      * @return A `BuildingStep` instance initialized with the generated request specification.
      */
-    public fun head(
+    public fun <P : Any> head(
         name: String? = null,
-        block: RequestSpecificationBuilder<*>.() -> Unit,
-    ): BuildingStep<RequestSpecification> = method(name, Head, block)
+        block: RequestSpecificationBuilder<P?>.() -> Unit,
+    ): BuildingStep<P?> = method(name, Head, block)
+
+    /**
+     * Configures a HTTP HEAD request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun head(block: RequestSpecificationBuilder<Any?>.() -> Unit): BuildingStep<Any?> =
+        this.head(null, block)
 
     /**
      * Configures an HTTP OPTIONS request specification using the provided block and returns a `BuildingStep`
      * instance for further customization. This method uses the HTTP OPTIONS method to define the request
      * specification within the provided lambda.
      *
+     * @param P type of the request payload
      * @param block A lambda used to configure the `RequestSpecificationBuilder` for the OPTIONS request.
      * @return A `BuildingStep` instance initialized with the generated request specification.
      */
-    public fun options(
+    public fun <P : Any> options(
         name: String? = null,
-        block: RequestSpecificationBuilder<*>.() -> Unit,
-    ): BuildingStep<RequestSpecification> = method(name, Options, block)
+        block: RequestSpecificationBuilder<P?>.() -> Unit,
+    ): BuildingStep<P?> = method(name, Options, block)
+
+    /**
+     * Configures a HTTP HEAD request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun options(block: RequestSpecificationBuilder<Any?>.() -> Unit): BuildingStep<Any?> =
+        this.options(null, block)
 
     /**
      * Retrieves a list of all request specifications that have not been matched to any incoming requests.
@@ -218,7 +295,7 @@ public open class MokksyServer(
      *
      * @return A list of unmatched request specifications.
      */
-    public fun findAllUnmatchedRequests(): List<RequestSpecification> =
+    public fun findAllUnmatchedRequests(): List<RequestSpecification<*>> =
         stubs
             .filter {
                 it.matchCount() == 0

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/Stub.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/Stub.kt
@@ -21,7 +21,7 @@ private val counter = AtomicLong()
  */
 internal data class Stub<T>(
     val name: String? = null,
-    val requestSpecification: RequestSpecification,
+    val requestSpecification: RequestSpecification<*>,
     val responseDefinition: AbstractResponseDefinition<T>,
 ) : Comparable<Stub<*>> {
     /**

--- a/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/BuildingStepTest.kt
+++ b/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/BuildingStepTest.kt
@@ -10,11 +10,11 @@ import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 internal class BuildingStepTest {
-    private lateinit var subject: BuildingStep<*>
+    private lateinit var subject: BuildingStep<Input>
 
     private lateinit var name: String
 
-    private lateinit var request: RequestSpecification
+    private lateinit var request: RequestSpecification<Input>
 
     private lateinit var stubs: MutableList<Stub<*>>
 
@@ -22,7 +22,7 @@ internal class BuildingStepTest {
     @BeforeTest
     fun before() {
         name = Uuid.random().toString()
-        request = mockk<RequestSpecification>()
+        request = mockk()
         stubs = mutableListOf()
 
         subject = BuildingStep(name, stubs, request)
@@ -30,7 +30,7 @@ internal class BuildingStepTest {
 
     @Test
     fun `Should handle respondsWith`() {
-        subject.respondsWith<Any> {}
+        subject.respondsWith<Output> {}
         assertThat(stubs).hasSize(
             1,
         )
@@ -41,7 +41,7 @@ internal class BuildingStepTest {
 
     @Test
     fun `Should handle respondsWithStream`() {
-        subject.respondsWithStream<Any> {}
+        subject.respondsWithStream<OutputChunk> {}
         assertThat(stubs).hasSize(
             1,
         )

--- a/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/TestTypes.kt
+++ b/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/TestTypes.kt
@@ -1,0 +1,18 @@
+package me.kpavlov.mokksy
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Input(
+    val name: String,
+)
+
+@Serializable
+data class Output(
+    val result: String,
+)
+
+@Serializable
+data class OutputChunk(
+    val item: String,
+)

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/MokksyIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/MokksyIT.kt
@@ -197,9 +197,9 @@ internal class MokksyIT : AbstractIT() {
                 }
                 """.trimIndent()
 
-            mokksy.post {
+            mokksy.post<Input>(name = "post") {
                 path = beEqual("/things")
-                bodyContains("\"$id\"")
+                bodyContains("$id")
             } respondsWith {
                 body = expectedResponse
                 httpStatus = HttpStatusCode.Created
@@ -218,7 +218,7 @@ internal class MokksyIT : AbstractIT() {
                         // language=json
                         """
                         {
-                            "id": "$id"
+                            "name": "the thing: $id"
                         }
                         """.trimIndent(),
                     )
@@ -229,5 +229,11 @@ internal class MokksyIT : AbstractIT() {
             assertThat(result.bodyAsText()).isEqualTo(expectedResponse)
             assertThat(result.headers["Location"]).isEqualTo("/things/$id")
             assertThat(result.headers["Foo"]).isEqualTo("bar")
+        }
+
+    @Test
+    fun `Should respond to shortcut POST`() =
+        runTest {
+            doTestCallMethod(HttpMethod.Post) { mokksy.post(it) }
         }
 }

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/MokksyIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/MokksyIT.kt
@@ -40,49 +40,85 @@ internal class MokksyIT : AbstractIT() {
         runTest {
             val method = HttpMethod.parse(methodName)
             doTestCallMethod(method) {
-                mokksy.method(name, method, it)
+                mokksy.method<Any>(name, method, it)
             }
         }
 
     @Test
     fun `Should respond to GET`() =
         runTest {
-            doTestCallMethod(HttpMethod.Get) { mokksy.get(name, it) }
+            doTestCallMethod(HttpMethod.Get) { mokksy.get<Any>(name, it) }
+        }
+
+    @Test
+    fun `Should respond to shortcut GET`() =
+        runTest {
+            doTestCallMethod(HttpMethod.Get) { mokksy.get(it) }
         }
 
     @Test
     fun `Should respond to OPTIONS`() =
         runTest {
-            doTestCallMethod(HttpMethod.Options) { mokksy.options(name, it) }
+            doTestCallMethod(HttpMethod.Options) { mokksy.options<Any>(name, it) }
+        }
+
+    @Test
+    fun `Should respond to shortcut OPTIONS`() =
+        runTest {
+            doTestCallMethod(HttpMethod.Options) { mokksy.options(it) }
         }
 
     @Test
     fun `Should respond to PUT`() =
         runTest {
-            doTestCallMethod(HttpMethod.Put) { mokksy.put(name, it) }
+            doTestCallMethod(HttpMethod.Put) { mokksy.put<Any>(name, it) }
+        }
+
+    @Test
+    fun `Should respond to shortcut PUT`() =
+        runTest {
+            doTestCallMethod(HttpMethod.Put) { mokksy.put(it) }
         }
 
     @Test
     fun `Should respond to PATCH`() =
         runTest {
-            doTestCallMethod(HttpMethod.Patch) { mokksy.patch(name, it) }
+            doTestCallMethod(HttpMethod.Patch) { mokksy.patch<Any>(name, it) }
+        }
+
+    @Test
+    fun `Should respond to shortcut PATCH`() =
+        runTest {
+            doTestCallMethod(HttpMethod.Patch) { mokksy.patch(it) }
         }
 
     @Test
     fun `Should respond to DELETE`() =
         runTest {
-            doTestCallMethod(HttpMethod.Delete) { mokksy.delete(name, it) }
+            doTestCallMethod(HttpMethod.Delete) { mokksy.delete<Any>(name, it) }
+        }
+
+    @Test
+    fun `Should respond to shortcut DELETE`() =
+        runTest {
+            doTestCallMethod(HttpMethod.Delete) { mokksy.delete(it) }
         }
 
     @Test
     fun `Should respond to HEAD`() =
         runTest {
-            doTestCallMethod(HttpMethod.Head) { mokksy.head(name, it) }
+            doTestCallMethod(HttpMethod.Head) { mokksy.head<Any>(name, it) }
+        }
+
+    @Test
+    fun `Should respond to shortcut HEAD`() =
+        runTest {
+            doTestCallMethod(HttpMethod.Head) { mokksy.head(it) }
         }
 
     private suspend fun doTestCallMethod(
         method: HttpMethod,
-        block: (RequestSpecificationBuilder<*>.() -> Unit) -> BuildingStep<RequestSpecification>,
+        block: (RequestSpecificationBuilder<*>.() -> Unit) -> BuildingStep<*>,
     ) {
         val expectedResponse =
             // language=json
@@ -133,7 +169,7 @@ internal class MokksyIT : AbstractIT() {
     fun `Should respond 404 to unmatched headers`() =
         runTest {
             val uri = "/unmatched-headers"
-            mokksy.get {
+            mokksy.get<Any> {
                 path = beEqual(uri)
                 this.containsHeader("Foo", "bar")
             } respondsWith {

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/MokksySSEIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/MokksySSEIT.kt
@@ -3,7 +3,7 @@ package me.kpavlov.mokksy
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import io.kotest.matchers.equals.beEqual
-import io.ktor.client.request.post
+import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -20,7 +20,7 @@ internal class MokksySSEIT : AbstractIT({ createKtorSSEClient(it) }) {
     @Test
     fun `Should respond to SSE GET`() =
         runTest {
-            mokksy.post {
+            mokksy.get<Any>(name = "sse-get") {
                 path = beEqual("/sse")
             } respondsWithSseStream {
                 flow =
@@ -41,7 +41,7 @@ internal class MokksySSEIT : AbstractIT({ createKtorSSEClient(it) }) {
             }
 
             // when
-            val result = client.post("/sse")
+            val result = client.get("/sse")
 
             // then
             assertThat(result.status).isEqualTo(HttpStatusCode.OK)

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/StubComparatorTest.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/StubComparatorTest.kt
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 
 internal class StubComparatorTest {
-    lateinit var request1: RequestSpecification
-    lateinit var request2: RequestSpecification
+    lateinit var request1: RequestSpecification<Int>
+    lateinit var request2: RequestSpecification<Int>
     lateinit var response: AbstractResponseDefinition<String>
 
     @BeforeEach


### PR DESCRIPTION
This pull request refactors the `RequestSpecification` and related components to introduce support for nullable and type-safe request payloads. The key changes are as follows:

- Generalized `RequestSpecification` to handle generic types, enabling type-safe payload handling.
- Provided clear separation between `body` and `bodyString` matchers, enhancing compatibility with `BuildingStep` and builders.
- Added support for nullable payloads (`P?` and `String?`), allowing more flexible matching techniques.
- Refined HTTP method helpers and tests to align with these updates.
- Enhanced the system to facilitate body matching for typed requests, with corresponding validation through custom matchers.
- Integrated Kotlin serialization into the build configuration to support typed deserialization.

These enhancements are aimed at improving extensibility, testability, and handling flexibility for request