### PR TITLE
Refactor project structure and enhance stub registration

### DIFF
--- a/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/ChatResponseSpecification.kt
+++ b/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/ChatResponseSpecification.kt
@@ -1,6 +1,6 @@
 package me.kpavlov.aimocks.core
 
-import me.kpavlov.mokksy.AbstractResponseDefinition
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
 
 public open class ChatResponseSpecification<T>(
     protected val response: AbstractResponseDefinition<T>,

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/OpenaiBuildingStep.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/OpenaiBuildingStep.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.json.encodeToJsonElement
 import me.kpavlov.aimocks.core.LlmBuildingStep
 import me.kpavlov.mokksy.BuildingStep
 import me.kpavlov.mokksy.MokksyServer
-import me.kpavlov.mokksy.StreamResponseDefinition
+import me.kpavlov.mokksy.response.StreamResponseDefinition
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/OpenaiChatResponseSpecification.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/OpenaiChatResponseSpecification.kt
@@ -2,7 +2,7 @@ package me.kpavlov.aimocks.openai
 
 import kotlinx.coroutines.flow.Flow
 import me.kpavlov.aimocks.core.ChatResponseSpecification
-import me.kpavlov.mokksy.AbstractResponseDefinition
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
 
 public class OpenaiChatResponseSpecification(
     response: AbstractResponseDefinition<String>,

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/BuildingStep.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/BuildingStep.kt
@@ -1,6 +1,10 @@
 package me.kpavlov.mokksy
 
 import io.ktor.sse.ServerSentEventMetadata
+import me.kpavlov.mokksy.request.RequestSpecification
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
+import me.kpavlov.mokksy.response.ResponseDefinitionBuilder
+import me.kpavlov.mokksy.response.StreamingResponseDefinitionBuilder
 
 /**
  * Defines the building step for associating an inbound request specification with its corresponding
@@ -27,7 +31,7 @@ public class BuildingStep<P> internal constructor(
      * This method is part of a fluent API for defining mappings between requests and responses.
      *
      * @param T The type of the response body.
-     * @param block A lambda function applied to a [ResponseDefinitionBuilder],
+     * @param block A lambda function applied to a [me.kpavlov.mokksy.response.ResponseDefinitionBuilder],
      * used to configure the response definition.
      */
     public infix fun <T> respondsWith(block: ResponseDefinitionBuilder<T>.() -> Unit) {
@@ -44,7 +48,7 @@ public class BuildingStep<P> internal constructor(
      * This method is part of a fluent API for defining mappings between requests and streaming responses.
      *
      * @param T The type of the elements in the streaming response data.
-     * @param block A lambda function applied to a [StreamingResponseDefinitionBuilder],
+     * @param block A lambda function applied to a [me.kpavlov.mokksy.response.StreamingResponseDefinitionBuilder],
      * used to configure the streaming response definition.
      */
     public infix fun <T> respondsWithStream(

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/MokksyServer.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/MokksyServer.kt
@@ -19,6 +19,9 @@ import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.ktor.server.sse.SSE
 import kotlinx.coroutines.runBlocking
+import me.kpavlov.mokksy.request.RequestSpecification
+import me.kpavlov.mokksy.request.RequestSpecificationBuilder
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import java.util.concurrent.ConcurrentSkipListSet
 
 internal expect fun createEmbeddedServer(

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/MokksyServer.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/MokksyServer.kt
@@ -118,12 +118,22 @@ public open class MokksyServer(
 
         return BuildingStep(
             name = name,
-            addStub = this::addStub,
+            registerStub = this::registerStub,
             requestSpecification = requestSpec,
         )
     }
 
-    private fun addStub(stub: Stub<*, *>) {
+    private fun <P> registerStub(
+        name: String? = null,
+        requestSpecification: RequestSpecification<P>,
+        responseDefinition: AbstractResponseDefinition<*>,
+    ) {
+        val stub =
+            Stub(
+                name = name,
+                requestSpecification = requestSpecification,
+                responseDefinition = responseDefinition,
+            )
         val added = stubs.add(stub)
         assert(added) { "Duplicate stub detected: $stub" }
     }

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/Stub.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/Stub.kt
@@ -2,6 +2,13 @@ package me.kpavlov.mokksy
 
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
+import me.kpavlov.mokksy.request.RequestSpecification
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
+import me.kpavlov.mokksy.response.ResponseDefinition
+import me.kpavlov.mokksy.response.SseStreamResponseDefinition
+import me.kpavlov.mokksy.response.StreamResponseDefinition
+import me.kpavlov.mokksy.response.respondWithSseStream
+import me.kpavlov.mokksy.response.respondWithStream
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/HeaderMarchers.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/HeaderMarchers.kt
@@ -1,4 +1,4 @@
-package me.kpavlov.mokksy
+package me.kpavlov.mokksy.request
 
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/RequestSpecification.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/RequestSpecification.kt
@@ -1,4 +1,4 @@
-package me.kpavlov.mokksy
+package me.kpavlov.mokksy.request
 
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.string.contain
@@ -138,7 +138,9 @@ public open class RequestSpecificationBuilder<P> {
         headerName: String,
         headerValue: String,
     ): RequestSpecificationBuilder<P> {
-        headers += me.kpavlov.mokksy.containsHeader(headerName, headerValue)
+        headers +=
+            me.kpavlov.mokksy.request
+                .containsHeader(headerName, headerValue)
         return this
     }
 

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/ResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/ResponseDefinition.kt
@@ -1,4 +1,4 @@
-package me.kpavlov.mokksy
+package me.kpavlov.mokksy.response
 
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/ResponseDefinitionBuilders.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/ResponseDefinitionBuilders.kt
@@ -1,4 +1,4 @@
-package me.kpavlov.mokksy
+package me.kpavlov.mokksy.response
 
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/ResponseHandler.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/ResponseHandler.kt
@@ -1,4 +1,4 @@
-package me.kpavlov.mokksy
+package me.kpavlov.mokksy.response
 
 import io.ktor.http.CacheControl
 import io.ktor.http.HttpHeaders

--- a/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/BuildingStepTest.kt
+++ b/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/BuildingStepTest.kt
@@ -6,6 +6,8 @@ import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import me.kpavlov.mokksy.request.RequestSpecification
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import kotlin.ranges.IntRange
 import kotlin.test.BeforeTest
 import kotlin.test.Test

--- a/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/BuildingStepTest.kt
+++ b/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/BuildingStepTest.kt
@@ -1,7 +1,12 @@
 package me.kpavlov.mokksy
 
 import io.kotest.matchers.shouldBe
+import io.ktor.http.HttpStatusCode
+import io.mockk.CapturingSlot
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import kotlin.ranges.IntRange
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.uuid.ExperimentalUuidApi
@@ -13,40 +18,70 @@ internal class BuildingStepTest {
     private lateinit var name: String
 
     private lateinit var request: RequestSpecification<Input>
+    private lateinit var expectedHttpStatus: HttpStatusCode
 
-    private lateinit var stub: Stub<Input, *>
+    private lateinit var stubName: CapturingSlot<String?>
+    private lateinit var requestSpecification: CapturingSlot<RequestSpecification<*>>
+    private lateinit var responseDefinition: CapturingSlot<AbstractResponseDefinition<*>>
 
-    private fun addStub(stub: Stub<Input, *>) {
-        this.stub = stub
-    }
+    private lateinit var registerStubCallback: (
+        name: String?,
+        requestSpecification: RequestSpecification<*>,
+        responseDefinition: AbstractResponseDefinition<*>,
+    ) -> Unit
 
     @OptIn(ExperimentalUuidApi::class)
     @BeforeTest
     fun before() {
         name = Uuid.random().toString()
         request = mockk()
+        registerStubCallback = mockk()
+        expectedHttpStatus = HttpStatusCode.fromValue(IntRange(100, 500).random())
 
-        subject = BuildingStep(name, this::addStub, request)
+        stubName = slot<String?>()
+        requestSpecification = slot<RequestSpecification<*>>()
+        responseDefinition = slot<AbstractResponseDefinition<*>>()
+
+        every {
+            registerStubCallback(
+                captureNullable(stubName),
+                capture(requestSpecification),
+                capture(responseDefinition),
+            )
+        } returns
+            Unit
+
+        subject = BuildingStep(name, registerStubCallback, request)
     }
 
     @Test
     fun `Should handle respondsWith`() {
-        subject.respondsWith<Output> {}
-        stub.name shouldBe name
-        stub.requestSpecification shouldBe request
+        subject.respondsWith<Output> {
+            httpStatus = expectedHttpStatus
+        }
+
+        verifyStub()
+    }
+
+    private fun verifyStub() {
+        stubName.captured shouldBe name
+        requestSpecification.captured shouldBe request
+        responseDefinition.captured.httpStatus shouldBe expectedHttpStatus
     }
 
     @Test
     fun `Should handle respondsWithStream`() {
-        subject.respondsWithStream<OutputChunk> {}
-        stub.name shouldBe name
-        stub.requestSpecification shouldBe request
+        subject.respondsWithStream<OutputChunk> {
+            httpStatus = expectedHttpStatus
+        }
+        verifyStub()
     }
 
     @Test
     fun `Should handle respondsWithSseStream`() {
-        subject.respondsWithSseStream<Any> {}
-        stub.name shouldBe name
-        stub.requestSpecification shouldBe request
+        subject.respondsWithSseStream<Output> {
+            httpStatus = expectedHttpStatus
+        }
+        verifyStub()
     }
 }

--- a/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/RequestSpecificationTest.kt
+++ b/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/RequestSpecificationTest.kt
@@ -20,6 +20,7 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import me.kpavlov.mokksy.request.RequestSpecification
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.Test

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/MokksyIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/MokksyIT.kt
@@ -12,6 +12,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
+import me.kpavlov.mokksy.request.RequestSpecificationBuilder
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/StubComparatorTest.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/StubComparatorTest.kt
@@ -4,6 +4,8 @@ import assertk.assertThat
 import assertk.assertions.isNegative
 import assertk.assertions.isPositive
 import assertk.assertions.isZero
+import me.kpavlov.mokksy.request.RequestSpecification
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock


### PR DESCRIPTION
### Description

This pull request includes the following changes:

- **Project Structure Refactor**: Restructured the codebase to group files into `request` and `response` packages for better organization and maintainability. Updated imports to align with the new structure. No functional changes were made.
  
- **Stub Registration Enhancement**: Replaced the `addStub` callback with a more robust `registerStub` method. The new method enables greater flexibility by supporting detailed parameters such as the name, request specification, and response definitions. Updated the `BuildingStep` class and its methods (`respondsWith`, `respondsWithStream`, `respondsWithSseStream`) to leverage the improved stub registration process. Tests have been adjusted to verify the updated behavior accurately.
