### PR TITLE
Add support for self-removal of stubs after matching

### DIFF
--- a/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/AbstractMockLlm.kt
+++ b/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/AbstractMockLlm.kt
@@ -2,13 +2,17 @@ package me.kpavlov.aimocks.core
 
 import io.ktor.server.application.log
 import me.kpavlov.mokksy.MokksyServer
+import me.kpavlov.mokksy.ServerConfiguration
 
 public abstract class AbstractMockLlm(
     port: Int = 0,
     verbose: Boolean = true,
 ) {
     protected val mokksy: MokksyServer =
-        MokksyServer(port = port, verbose = verbose) {
+        MokksyServer(
+            port = port,
+            configuration = ServerConfiguration(verbose),
+        ) {
             it.log.info("Running Mokksy with ${it.engine} engine")
         }
 

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/ServerConfiguration.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/ServerConfiguration.kt
@@ -1,0 +1,5 @@
+package me.kpavlov.mokksy
+
+public data class ServerConfiguration(
+    val verbose: Boolean = false,
+)

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/Stub.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/Stub.kt
@@ -29,7 +29,7 @@ private val counter = AtomicLong()
  * @property responseDefinitionSupplier Function providing responseDefinition.
  */
 internal data class Stub<P, T>(
-    val name: String? = null,
+    val configuration: StubConfiguration,
     val requestSpecification: RequestSpecification<P>,
     val responseDefinitionSupplier: ResponseDefinitionSupplier<P, T>,
 ) : Comparable<Stub<*, *>> {
@@ -103,10 +103,10 @@ internal data class Stub<P, T>(
     fun matchCount(): Int = matchCount.toInt()
 
     fun toLogString(): String =
-        if (name?.isNotBlank() == true) {
-            "Stub('$name')[requestSpec=${requestSpecification.toLogString()}]"
+        if (configuration.name?.isNotBlank() == true) {
+            "Stub('${configuration.name}')[config=$configuration requestSpec=${requestSpecification.toLogString()}]"
         } else {
-            "Stub[requestSpec=${requestSpecification.toLogString()}]"
+            "Stub[config=$configuration requestSpec=${requestSpecification.toLogString()}]"
         }
 }
 

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/StubConfiguration.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/StubConfiguration.kt
@@ -1,0 +1,7 @@
+package me.kpavlov.mokksy
+
+public data class StubConfiguration(
+    val name: String? = null,
+    val removeAfterMatch: Boolean = false,
+    val verbose: Boolean = false,
+)

--- a/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/BuildingStepTest.kt
+++ b/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/BuildingStepTest.kt
@@ -22,6 +22,7 @@ internal class BuildingStepTest {
     private lateinit var expectedHttpStatus: HttpStatusCode
 
     private lateinit var stub: CapturingSlot<Stub<*, *>>
+    private lateinit var configuration: CapturingSlot<StubConfiguration>
     private lateinit var requestSpecification: CapturingSlot<RequestSpecification<*>>
 
     private lateinit var addStubCallback: (
@@ -34,6 +35,7 @@ internal class BuildingStepTest {
         name = Uuid.random().toString()
         request = mockk()
         addStubCallback = mockk()
+        configuration = mockk()
         expectedHttpStatus = HttpStatusCode.fromValue(IntRange(100, 500).random())
 
         stub = slot<Stub<*, *>>()
@@ -80,7 +82,7 @@ internal class BuildingStepTest {
 
     private fun verifyStub() {
         stub.captured.apply {
-            this.name shouldBe name
+            this.configuration.name shouldBe name
             this.requestSpecification shouldBe request
             this.responseDefinitionSupplier shouldNotBeNull { }
         }

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/RemoveAfterUseIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/RemoveAfterUseIT.kt
@@ -1,0 +1,31 @@
+package me.kpavlov.mokksy
+
+import io.kotest.matchers.equals.beEqual
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class RemoveAfterUseIT : AbstractIT() {
+    @Test
+    fun `Should remove Stub after match`() =
+        runTest {
+            val uri = "/remove-after-match"
+            mokksy.get(
+                configuration =
+                    StubConfiguration(
+                        removeAfterMatch = true,
+                        verbose = true,
+                    ),
+            ) {
+                path = beEqual(uri)
+            } respondsWith {
+                body = "🇪🇪 Tere!"
+            }
+            // First request should succeed
+            client.get(uri).status shouldBe HttpStatusCode.OK
+            // Next request should fail as stub is self-removed
+            client.get(uri).status shouldBe HttpStatusCode.NotFound
+        }
+}

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/StubComparatorTest.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/StubComparatorTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isNegative
 import assertk.assertions.isPositive
 import assertk.assertions.isZero
+import io.mockk.mockk
 import me.kpavlov.mokksy.request.RequestSpecification
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import me.kpavlov.mokksy.response.ResponseDefinitionSupplier
@@ -14,12 +15,14 @@ import org.mockito.kotlin.mock
 internal class StubComparatorTest {
     lateinit var request1: RequestSpecification<Int>
     lateinit var request2: RequestSpecification<Int>
+    lateinit var config: StubConfiguration
     lateinit var response: AbstractResponseDefinition<Any, String>
     lateinit var responseDefinitionSupplier: ResponseDefinitionSupplier<Int, String>
 
     @BeforeEach
     fun beforeEach() {
         response = mock()
+        config = mockk()
         responseDefinitionSupplier = mock()
     }
 
@@ -30,11 +33,13 @@ internal class StubComparatorTest {
 
         val stub1 =
             Stub<Int, String>(
+                configuration = config,
                 requestSpecification = request1,
                 responseDefinitionSupplier = responseDefinitionSupplier,
             )
         val stub2 =
             Stub(
+                configuration = config,
                 requestSpecification = request2,
                 responseDefinitionSupplier = responseDefinitionSupplier,
             )
@@ -51,11 +56,13 @@ internal class StubComparatorTest {
 
         val stub1 =
             Stub(
+                configuration = config,
                 requestSpecification = request1,
                 responseDefinitionSupplier = responseDefinitionSupplier,
             )
         val stub2 =
             Stub(
+                configuration = config,
                 requestSpecification = request2,
                 responseDefinitionSupplier = responseDefinitionSupplier,
             )
@@ -72,11 +79,13 @@ internal class StubComparatorTest {
 
         val stub1 =
             Stub(
+                configuration = config,
                 requestSpecification = request1,
                 responseDefinitionSupplier = responseDefinitionSupplier,
             )
         val stub2 =
             Stub(
+                configuration = config,
                 requestSpecification = request2,
                 responseDefinitionSupplier = responseDefinitionSupplier,
             )
@@ -92,6 +101,7 @@ internal class StubComparatorTest {
 
         val stub1 =
             Stub(
+                configuration = config,
                 requestSpecification = request1,
                 responseDefinitionSupplier = responseDefinitionSupplier,
             )


### PR DESCRIPTION
## Add support for self-removal of stubs after matching

- Introduced the `StubConfiguration` class to enable configurable behavior for the stubs, including a `removeAfterMatch` feature. Updated request handling to remove stubs after they are matched if configured. Added integration and unit tests to validate the functionality.
- Replaced `verbose` boolean with a ServerConfiguration object to enable more flexible server settings. Updated related methods and constructors across MokksyServer and AbstractMockLlm to accommodate the change.