### PR TITLE
Model deserialization fix

### DIFF
--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/Model.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/Model.kt
@@ -10,6 +10,8 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+// Full OpenAPI Spec is here: https://raw.githubusercontent.com/openai/openai-openapi/refs/heads/master/openapi.yaml
+
 @Serializable
 internal data class Chunk(
     val id: String,
@@ -135,6 +137,7 @@ public data class ChatCompletionRequest(
     val responseFormat: ResponseFormat? = null,
     val temperature: Double = 1.0,
     val seed: Int? = null,
+    val stream: Boolean = false,
 )
 
 @Serializable

--- a/ai-mocks-openai/src/commonTest/kotlin/me/kpavlov/aimocks/openai/ModelDeserializationTest.kt
+++ b/ai-mocks-openai/src/commonTest/kotlin/me/kpavlov/aimocks/openai/ModelDeserializationTest.kt
@@ -1,0 +1,36 @@
+package me.kpavlov.aimocks.openai
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+
+internal class ModelDeserializationTest {
+    val jsonParser =
+        Json {
+            ignoreUnknownKeys = false
+        }
+
+    @Test
+    fun `Should deserialize model`() {
+        val json =
+            // language=json
+            """
+            {
+              "messages" : [ {
+                "content" : "You are a helpful assistant",
+                "role" : "system"
+              }, {
+                "content" : "Help me, please",
+                "role" : "user"
+              } ],
+              "model" : "gpt-4o-mini",
+              "response_format" : {
+                "type" : "json_object"
+              },
+              "stream" : false,
+              "temperature" : 0.0
+            }
+            """.trimIndent()
+
+        jsonParser.decodeFromString<ChatCompletionRequest>(json)
+    }
+}

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/lc4j/ChatCompletionLc4jTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/lc4j/ChatCompletionLc4jTest.kt
@@ -1,6 +1,7 @@
 package me.kpavlov.aimocks.openai.lc4j
 
 import dev.langchain4j.data.message.UserMessage.userMessage
+import dev.langchain4j.model.chat.chat
 import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters
 import dev.langchain4j.model.output.FinishReason
@@ -9,7 +10,6 @@ import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.test.runTest
 import me.kpavlov.aimocks.openai.AbstractMockOpenaiTest
 import me.kpavlov.aimocks.openai.openai
-import me.kpavlov.langchain4j.kotlin.model.chat.chatAsync
 import kotlin.test.Test
 
 internal class ChatCompletionLc4jTest : AbstractMockOpenaiTest() {
@@ -34,7 +34,7 @@ internal class ChatCompletionLc4jTest : AbstractMockOpenaiTest() {
             }
 
             val result =
-                model.chatAsync {
+                model.chat {
                     parameters =
                         OpenAiChatRequestParameters
                             .builder()


### PR DESCRIPTION
- Added a new `stream` property to the `ChatCompletionRequest` model with a default value of `false`. Ensured proper JSON deserialization by adding a corresponding test. 
- Refactored `ChatCompletionLc4jTest` to use the `chat` method from LC4J.
