### PR TITLE
Add Jackson support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ _Mokksy_ and _AI-Mocks_ are mock HTTP and LLM (Large Language Model) servers ins
 - Fluent modern Kotlin DSL API.
 - Support for simulating streamed responses and Server-Side Events (SSE) with delays between chunks.
 - Support for simulating response delays.
+- Supports [serialization](https://ktor.io/docs/server-serialization.html#add_json_dependency) with [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) and [Jackson](https://github.com/FasterXML/jackson) (only on JVM)
 
 ## Example Usages
 

--- a/ai-mocks-core/build.gradle.kts
+++ b/ai-mocks-core/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(project(":mokksy"))
+                implementation(project.dependencies.platform(libs.ktor.bom))
             }
         }
     }

--- a/ai-mocks-openai/build.gradle.kts
+++ b/ai-mocks-openai/build.gradle.kts
@@ -11,12 +11,14 @@ kotlin {
         commonMain {
             dependencies {
                 api(project(":ai-mocks-core"))
+                implementation(project.dependencies.platform(libs.ktor.bom))
                 api(libs.ktor.serialization.kotlinx.json)
             }
         }
 
         commonTest {
             dependencies {
+                implementation(kotlin("test"))
                 implementation(libs.assertk)
                 implementation(libs.kotlinx.coroutines.test)
             }

--- a/buildSrc/src/main/kotlin/kotlin-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-convention.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
     jvm {
         compilerOptions {
             jvmTarget = JvmTarget.JVM_17
+            javaParameters = true
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ awaitility = "4.3.0"
 datafaker = "2.4.2"
 detekt = "1.23.8"
 dokka = "2.0.0"
+jackson = "2.18.3"
 junitJupiter = "5.12.0"
 kotest = "5.9.1"
 kotlin = "2.1.10"
@@ -18,6 +19,7 @@ mockk = "1.13.17"
 netty = "4.1.119.Final"
 nexusPublish = "2.0.0"
 openai = "0.30.0"
+openapiGenerator = "7.12.0"
 openrewrite = "7.1.7"
 slf4j = "2.0.17"
 spotless = "7.0.2"
@@ -34,29 +36,32 @@ kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.
 kotest-assertions-json = { module = "io.kotest:kotest-assertions-json", version.ref = "kotest" }
 kotlinLogging = { module = "io.github.oshai:kotlin-logging", version.ref = "kotlinLogging" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx" }
-ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
-ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
-ktor-client-java = { module = "io.ktor:ktor-client-java", version.ref = "ktor" }
-ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ktor-server-call-logging = { module = "io.ktor:ktor-server-call-logging", version.ref = "ktor" }
-ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
-ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
-ktor-server-double-receive = { module = "io.ktor:ktor-server-double-receive", version.ref = "ktor" }
-ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
-ktor-server-sse = { module = "io.ktor:ktor-server-sse", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation" }
+ktor-client-core = { module = "io.ktor:ktor-client-core" }
+ktor-client-java = { module = "io.ktor:ktor-client-java" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json" }
+ktor-bom = { module = "io.ktor:ktor-bom", version.ref = "ktor" }
+ktor-serialization-jackson = { module = "io.ktor:ktor-serialization-jackson" }
+ktor-server-call-logging = { module = "io.ktor:ktor-server-call-logging" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation" }
+ktor-server-core = { module = "io.ktor:ktor-server-core" }
+ktor-server-double-receive = { module = "io.ktor:ktor-server-double-receive" }
+ktor-server-netty = { module = "io.ktor:ktor-server-netty" }
+ktor-server-sse = { module = "io.ktor:ktor-server-sse" }
 langchain4j-bom = { group = "dev.langchain4j", name = "langchain4j-bom", version.ref = "langchain4j" }
 langchain4j-kotlin = { group = "me.kpavlov.langchain4j.kotlin", name = "langchain4j-kotlin", version.ref = "langchain4jKotlin" }
 langchain4j-openai = { group = "dev.langchain4j", name = "langchain4j-open-ai", version.ref = "langchain4j" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-dsl = { module = "io.mockk:mockk-dsl", version.ref = "mockk" }
-netty = { group = "io.netty", name = "netty-handler", version.ref = "netty" }
+netty-bom = { group = "io.netty", name = "netty-bom", version.ref = "netty" }
 openai-java = { group = "com.openai", name = "openai-java", version.ref = "openai" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 spring-bom = { group = "org.springframework", name = "spring-framework-bom", version.ref = "spring" }
 spring-context = { group = "org.springframework", name = "spring-context" }
 spring-test = { group = "org.springframework", name = "spring-test" }
-spring-ai-bom = { group = "org.springframework.ai", name="spring-ai-bom", version.ref = "spring-ai" }
-spring-ai-openai = { group = "org.springframework.ai", name="spring-ai-openai" }
+spring-ai-bom = { group = "org.springframework.ai", name = "spring-ai-bom", version.ref = "spring-ai" }
+spring-ai-openai = { group = "org.springframework.ai", name = "spring-ai-openai" }
+jackson-bom = { group = "com.fasterxml.jackson", name = "jackson-bom", version.ref = "jackson" }
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
@@ -66,3 +71,4 @@ kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 openrewrite = { id = "org.openrewrite.rewrite", version.ref = "openrewrite" }
+openapiGenerator = { id = "org.openapi.generator", version.ref = "openapiGenerator" }

--- a/mokksy/build.gradle.kts
+++ b/mokksy/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
                 api(libs.kotest.assertions.core)
                 api(libs.kotest.assertions.json)
                 api(libs.ktor.server.core)
+                implementation(project.dependencies.platform(libs.ktor.bom))
                 implementation(libs.ktor.server.double.receive)
                 implementation(libs.ktor.server.content.negotiation)
                 implementation(libs.ktor.serialization.kotlinx.json)
@@ -36,6 +37,9 @@ kotlin {
 
         jvmMain {
             dependencies {
+                implementation(project.dependencies.platform(libs.jackson.bom))
+                implementation(project.dependencies.platform(libs.netty.bom))
+                implementation(libs.ktor.serialization.jackson)
                 implementation(libs.ktor.server.netty)
                 implementation(libs.ktor.server.call.logging)
             }
@@ -49,4 +53,9 @@ kotlin {
             }
         }
     }
+}
+dependencies {
+    implementation("io.ktor:ktor-server-content-negotiation-jvm:3.1.1")
+    implementation("io.ktor:ktor-server-core-jvm:3.1.1")
+    implementation("io.ktor:ktor-serialization-jackson-jvm:3.1.1")
 }

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/MokksyServer.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/MokksyServer.kt
@@ -10,18 +10,17 @@ import io.ktor.http.HttpMethod.Companion.Options
 import io.ktor.http.HttpMethod.Companion.Patch
 import io.ktor.http.HttpMethod.Companion.Post
 import io.ktor.http.HttpMethod.Companion.Put
-import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig
 import io.ktor.server.plugins.doublereceive.DoubleReceive
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.ktor.server.sse.SSE
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.Json
 import me.kpavlov.mokksy.request.RequestSpecification
 import me.kpavlov.mokksy.request.RequestSpecificationBuilder
 import java.util.concurrent.ConcurrentSkipListSet
@@ -36,6 +35,8 @@ internal expect fun createEmbeddedServer(
     out ApplicationEngine,
     out ApplicationEngine.Configuration,
 >
+
+internal expect fun configureContentNegotiation(config: ContentNegotiationConfig)
 
 /**
  * Represents an embedded mock server capable of handling various HTTP requests and responses for testing purposes.
@@ -88,11 +89,7 @@ public open class MokksyServer(
             install(DoubleReceive)
 
             install(ContentNegotiation) {
-                json(
-                    Json {
-                        ignoreUnknownKeys = true
-                    },
-                )
+                configureContentNegotiation(this)
             }
 
             routing {

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/AbstractResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/AbstractResponseDefinition.kt
@@ -4,6 +4,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.ResponseHeaders
+import kotlin.reflect.KClass
 import kotlin.time.Duration
 
 internal typealias ResponseDefinitionSupplier<P, T> = (
@@ -21,8 +22,9 @@ internal typealias ResponseDefinitionSupplier<P, T> = (
  * @property headers A lambda function for configuring the response headers. Defaults to `null`.
  * @property headerList A list of header key-value pairs to populate the response headers. Defaults to an empty list.
  */
-public abstract class AbstractResponseDefinition<T>(
+public abstract class AbstractResponseDefinition<T : Any>(
     public val contentType: ContentType? = null,
+    public val responseType: KClass<T>? = null,
     public val httpStatus: HttpStatusCode = HttpStatusCode.OK,
     public val headers: (ResponseHeaders.() -> Unit)? = null,
     public val headerList: List<Pair<String, String>> = emptyList<Pair<String, String>>(),

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/ResponseDefinitionBuilders.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/ResponseDefinitionBuilders.kt
@@ -6,6 +6,7 @@ import io.ktor.server.response.ResponseHeaders
 import kotlinx.coroutines.flow.Flow
 import me.kpavlov.mokksy.CapturedRequest
 import java.util.Collections
+import kotlin.reflect.KClass
 import kotlin.time.Duration
 
 /**
@@ -18,10 +19,12 @@ import kotlin.time.Duration
  * @property httpStatus The HTTP status code to be associated with the response.
  * @property headers A mutable list of header key-value pairs to be included in the response.
  */
-public abstract class AbstractResponseDefinitionBuilder<P, T>(
+public abstract class AbstractResponseDefinitionBuilder<P, T : Any>(
     public var httpStatus: HttpStatusCode,
     public val headers: MutableList<Pair<String, String>>,
 ) {
+//    protected abstract fun responseType(): KClass<T>
+
     /**
      * A lambda function for configuring additional response headers.
      * This function can define custom headers or override existing ones.
@@ -62,6 +65,7 @@ public abstract class AbstractResponseDefinitionBuilder<P, T>(
 public open class ResponseDefinitionBuilder<P : Any, T : Any>(
     public val request: CapturedRequest<P>,
     public var contentType: ContentType? = null,
+    public var responseType: KClass<T>? = null,
     public var body: T? = null,
     public var delay: Duration = Duration.ZERO,
     httpStatus: HttpStatusCode = HttpStatusCode.OK,
@@ -71,6 +75,7 @@ public open class ResponseDefinitionBuilder<P : Any, T : Any>(
         ResponseDefinition<P, T>(
             body = body,
             contentType = contentType ?: ContentType.Application.Json,
+            responseType = responseType,
             httpStatus = httpStatus,
             headers = headersLambda,
             headerList = Collections.unmodifiableList(headers),
@@ -91,8 +96,9 @@ public open class ResponseDefinitionBuilder<P : Any, T : Any>(
  *          if [flow] is not provided.
  */
 @Suppress("LongParameterList")
-public open class StreamingResponseDefinitionBuilder<P : Any, T>(
+public open class StreamingResponseDefinitionBuilder<P : Any, T : Any>(
     public val request: CapturedRequest<P>,
+    public var responseType: KClass<T>? = null,
     public var flow: Flow<T>? = null,
     public var chunks: MutableList<T> = mutableListOf(),
     public var delayBetweenChunks: Duration = Duration.ZERO,
@@ -121,5 +127,6 @@ public open class StreamingResponseDefinitionBuilder<P : Any, T>(
             headerList = Collections.unmodifiableList(headers),
             delayBetweenChunks = delayBetweenChunks,
             delay = delay,
+            responseType = responseType,
         )
 }

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/StreamResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/StreamResponseDefinition.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.yield
 import java.io.Writer
+import kotlin.reflect.KClass
 import kotlin.time.Duration
 
 /**
@@ -34,17 +35,19 @@ import kotlin.time.Duration
  * @see AbstractResponseDefinition
  */
 @Suppress("LongParameterList")
-public open class StreamResponseDefinition<P, T>(
+public open class StreamResponseDefinition<P, T : Any>(
     public open val chunkFlow: Flow<T>? = null,
     public val chunks: List<T>? = null,
     public val delayBetweenChunks: Duration = Duration.ZERO,
     contentType: ContentType = ContentType.Text.EventStream.withCharset(Charsets.UTF_8),
+    responseType: KClass<T>? = null,
     httpStatus: HttpStatusCode = HttpStatusCode.OK,
     headers: (ResponseHeaders.() -> Unit)? = null,
     headerList: List<Pair<String, String>> = emptyList<Pair<String, String>>(),
     delay: Duration,
 ) : AbstractResponseDefinition<T>(
         contentType,
+        responseType,
         httpStatus,
         headers,
         headerList,

--- a/mokksy/src/jvmMain/kotlin/me/kpavlov/mokksy/MokksyServer.jvm.kt
+++ b/mokksy/src/jvmMain/kotlin/me/kpavlov/mokksy/MokksyServer.jvm.kt
@@ -1,5 +1,8 @@
 package me.kpavlov.mokksy
 
+import com.fasterxml.jackson.databind.DeserializationFeature
+import io.ktor.serialization.jackson.jackson
+import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.engine.ApplicationEngine
@@ -7,6 +10,8 @@ import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.plugins.calllogging.CallLogging
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig
+import kotlinx.serialization.json.Json
 import org.slf4j.event.Level
 
 internal actual fun createEmbeddedServer(
@@ -25,6 +30,18 @@ internal actual fun createEmbeddedServer(
     ) {
         module()
         install(CallLogging) {
-            this.level = if (configuration.verbose) Level.DEBUG else Level.INFO
+            level = if (configuration.verbose) Level.DEBUG else Level.INFO
         }
     }
+
+internal actual fun configureContentNegotiation(config: ContentNegotiationConfig) {
+    config.jackson {
+        findAndRegisterModules()
+        disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    }
+    config.json(
+        Json {
+            ignoreUnknownKeys = true
+        },
+    )
+}

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/jackson/JacksonSerializationIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/jackson/JacksonSerializationIT.kt
@@ -1,0 +1,54 @@
+package me.kpavlov.mokksy
+
+import io.kotest.matchers.equals.beEqual
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.java.Java
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.jackson.jackson
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class JacksonSerializationIT : AbstractIT() {
+    private val jacksonClient =
+        HttpClient(Java) {
+            install(ContentNegotiation) {
+                jackson()
+            }
+            install(DefaultRequest) {
+                url("http://127.0.0.1:${mokksy.port()}") // Set the base URL
+            }
+        }
+
+    @Test
+    fun `Should respond to POST with Jackson`() =
+        runTest {
+            mokksy.post(
+                requestType = JacksonInput::class,
+            ) {
+                path = beEqual("/jackson")
+            } respondsWith {
+                body = JacksonOutput("Hello, ${request.body.name}")
+            }
+
+            val result =
+                jacksonClient.post("/jackson") {
+                    contentType(ContentType.Application.Json)
+                    setBody(JacksonInput("Bob"))
+                }
+            result.status shouldBe HttpStatusCode.OK
+
+            result.bodyAsText() shouldBe
+                // language=json
+                """
+                {"pikka-hi":"Hello, Bob"}
+                """.trimIndent()
+        }
+}

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/jackson/JacksonTestTypes.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/jackson/JacksonTestTypes.kt
@@ -1,0 +1,12 @@
+package me.kpavlov.mokksy
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+internal data class JacksonInput(
+    @JsonProperty val name: String,
+)
+
+internal data class JacksonOutput(
+    @JsonProperty("pikka-hi")
+    val greeting: String,
+)


### PR DESCRIPTION
### Description

This pull request introduces the following changes:
- **Jackson and kotlinx.serialization**: Added support for JSON serialization tailored for JVM targets with response type metadata for enhanced flexibility and compatibility.
- **Dependency management enhancements**: Integrated Ktor BOM for consistent versioning. Jackson and Netty BOMs are also added to improve serialization and testing reliability. 
- Updated `javaParameters` in the JVM configurations to optimize runtime reflection.
- Comprehensive tests were introduced to validate Jackson-based serialization.