### PR TITLE
Add Jackson support and improve content negotiation configuration

### DIFF
--- a/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/AbstractMockLlm.kt
+++ b/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/AbstractMockLlm.kt
@@ -6,12 +6,12 @@ import me.kpavlov.mokksy.ServerConfiguration
 
 public abstract class AbstractMockLlm(
     port: Int = 0,
-    verbose: Boolean = true,
+    configuration: ServerConfiguration,
 ) {
     protected val mokksy: MokksyServer =
         MokksyServer(
             port = port,
-            configuration = ServerConfiguration(verbose),
+            configuration = configuration,
         ) {
             it.log.info("Running Mokksy with ${it.engine} engine")
         }

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/MockOpenai.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/MockOpenai.kt
@@ -2,7 +2,10 @@ package me.kpavlov.aimocks.openai
 
 import io.kotest.assertions.json.containJsonKeyValue
 import io.kotest.matchers.equals.beEqual
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
 import me.kpavlov.aimocks.core.AbstractMockLlm
+import me.kpavlov.mokksy.ServerConfiguration
 import java.util.function.Consumer
 
 public open class MockOpenai(
@@ -10,7 +13,14 @@ public open class MockOpenai(
     verbose: Boolean = true,
 ) : AbstractMockLlm(
         port = port,
-        verbose = verbose,
+        configuration =
+            ServerConfiguration(
+                verbose = verbose,
+            ) { config ->
+                config.json(
+                    Json { ignoreUnknownKeys = true },
+                )
+            },
     ) {
     /**
      * Java-friendly overload that accepts a Consumer for configuring the chat request.

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/OpenaiBuildingStep.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/OpenaiBuildingStep.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.encodeToJsonElement
 import me.kpavlov.aimocks.core.LlmBuildingStep
 import me.kpavlov.mokksy.BuildingStep
 import me.kpavlov.mokksy.MokksyServer
@@ -45,7 +44,7 @@ public class OpenaiBuildingStep(
             val rejectedPredictionTokens =
                 completionTokens - reasoningTokens - acceptedPredictionTokens
 
-            val response =
+            body =
                 ChatResponse(
                     id = "chatcmpl-abc${counter.addAndGet(1)}",
                     created = Instant.now().epochSecond,
@@ -76,8 +75,6 @@ public class OpenaiBuildingStep(
                         ),
                     systemFingerprint = "fp_44709d6fcb",
                 )
-
-            body = response
         }
     }
 
@@ -195,7 +192,6 @@ public class OpenaiBuildingStep(
                 created = created,
                 systemFingerprint = "fp_44709d6fcb",
             )
-        val string = Json.encodeToJsonElement(chunk).toString()
-        return string
+        return Json.encodeToString(chunk)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-java = { module = "io.ktor:ktor-client-java", version.ref = "ktor" }
+ktor-serialization-jackson = { module = "io.ktor:ktor-serialization-jackson", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-call-logging = { module = "io.ktor:ktor-server-call-logging", version.ref = "ktor" }
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }

--- a/mokksy/build.gradle.kts
+++ b/mokksy/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
                 api(libs.kotest.assertions.json)
                 api(libs.ktor.server.core)
                 implementation(libs.ktor.server.double.receive)
-                implementation(libs.ktor.server.content.negotiation)
+                api(libs.ktor.server.content.negotiation)
                 implementation(libs.ktor.serialization.kotlinx.json)
                 implementation(libs.ktor.server.sse)
             }
@@ -46,6 +46,7 @@ kotlin {
                 implementation(libs.ktor.client.java)
                 implementation(libs.junit.jupiter.params)
                 runtimeOnly(libs.slf4j.simple)
+                implementation(libs.ktor.serialization.jackson)
             }
         }
     }

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/MokksyServer.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/MokksyServer.kt
@@ -10,18 +10,17 @@ import io.ktor.http.HttpMethod.Companion.Options
 import io.ktor.http.HttpMethod.Companion.Patch
 import io.ktor.http.HttpMethod.Companion.Post
 import io.ktor.http.HttpMethod.Companion.Put
-import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig
 import io.ktor.server.plugins.doublereceive.DoubleReceive
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.ktor.server.sse.SSE
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.Json
 import me.kpavlov.mokksy.request.RequestSpecification
 import me.kpavlov.mokksy.request.RequestSpecificationBuilder
 import java.util.concurrent.ConcurrentSkipListSet
@@ -36,6 +35,8 @@ internal expect fun createEmbeddedServer(
     out ApplicationEngine,
     out ApplicationEngine.Configuration,
 >
+
+internal expect fun configureContentNegotiation(config: ContentNegotiationConfig)
 
 /**
  * Represents an embedded mock server capable of handling various HTTP requests and responses for testing purposes.
@@ -88,11 +89,7 @@ public open class MokksyServer(
             install(DoubleReceive)
 
             install(ContentNegotiation) {
-                json(
-                    Json {
-                        ignoreUnknownKeys = true
-                    },
-                )
+                configuration.contentNegotiationConfigurer(this)
             }
 
             routing {

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/ServerConfiguration.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/ServerConfiguration.kt
@@ -1,5 +1,10 @@
 package me.kpavlov.mokksy
 
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig
+
 public data class ServerConfiguration(
     val verbose: Boolean = false,
+    val contentNegotiationConfigurer: (
+        ContentNegotiationConfig,
+    ) -> Unit = ::configureContentNegotiation,
 )

--- a/mokksy/src/jvmMain/kotlin/me/kpavlov/mokksy/MokksyServer.jvm.kt
+++ b/mokksy/src/jvmMain/kotlin/me/kpavlov/mokksy/MokksyServer.jvm.kt
@@ -1,5 +1,6 @@
 package me.kpavlov.mokksy
 
+import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.engine.ApplicationEngine
@@ -7,6 +8,9 @@ import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.plugins.calllogging.CallLogging
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
 import org.slf4j.event.Level
 
 internal actual fun createEmbeddedServer(
@@ -25,6 +29,15 @@ internal actual fun createEmbeddedServer(
     ) {
         module()
         install(CallLogging) {
-            this.level = if (configuration.verbose) Level.DEBUG else Level.INFO
+            level = if (configuration.verbose) Level.DEBUG else Level.INFO
         }
     }
+
+@OptIn(ExperimentalSerializationApi::class)
+internal actual fun configureContentNegotiation(config: ContentNegotiationConfig) {
+    config.json(
+        Json {
+            ignoreUnknownKeys = true
+        },
+    )
+}

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/jackson/JacksonSerializationIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/jackson/JacksonSerializationIT.kt
@@ -1,0 +1,70 @@
+package me.kpavlov.mokksy.jackson
+
+import io.kotest.matchers.equals.beEqual
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.java.Java
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.jackson.jackson
+import kotlinx.coroutines.test.runTest
+import me.kpavlov.mokksy.AbstractIT
+import me.kpavlov.mokksy.MokksyServer
+import me.kpavlov.mokksy.ServerConfiguration
+import org.junit.jupiter.api.Test
+
+private val mokksyWithJackson: MokksyServer =
+    MokksyServer(
+        configuration =
+            ServerConfiguration(
+                verbose = true,
+                contentNegotiationConfigurer = {
+                    it.jackson {
+                        findAndRegisterModules()
+                    }
+                },
+            ),
+    )
+
+internal class JacksonSerializationIT : AbstractIT() {
+    private val jacksonClient =
+        HttpClient(Java) {
+            install(ContentNegotiation) {
+                jackson()
+            }
+            install(DefaultRequest) {
+                url("http://127.0.0.1:${mokksyWithJackson.port()}") // Set the base URL
+            }
+        }
+
+    @Test
+    fun `Should respond to POST with Jackson`() =
+        runTest {
+            mokksyWithJackson.post<JacksonInput>(
+                requestType = JacksonInput::class,
+            ) {
+                path = beEqual("/jackson-$seed")
+            } respondsWith {
+                body = JacksonOutput("Hello, ${request.body.name}")
+            }
+
+            val result =
+                jacksonClient.post("/jackson-$seed") {
+                    contentType(ContentType.Application.Json)
+                    setBody(JacksonInput("Bob"))
+                }
+            result.status shouldBe HttpStatusCode.OK
+
+            result.bodyAsText() shouldBe
+                // language=json
+                """
+                {"pikka-hi":"Hello, Bob"}
+                """.trimIndent()
+        }
+}

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/jackson/JacksonTestTypes.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/jackson/JacksonTestTypes.kt
@@ -1,0 +1,12 @@
+package me.kpavlov.mokksy.jackson
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+internal data class JacksonInput(
+    @JsonProperty val name: String,
+)
+
+internal data class JacksonOutput(
+    @JsonProperty("pikka-hi")
+    val greeting: String,
+)


### PR DESCRIPTION
This commit introduces support for Jackson serialization/deserialization in Mokksy. It refactors `ServerConfiguration` to allow customizable content negotiation via a functional parameter. Additionally, a new integration test validates the Jackson serialization setup.