### PR TITLE
Add response delay customization in OpenAI mocks

### DIFF
--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/OpenaiChatResponseSpecification.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/OpenaiChatResponseSpecification.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import me.kpavlov.aimocks.core.ChatResponseSpecification
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 @Suppress("LongParameterList")
 public class OpenaiChatResponseSpecification(
@@ -25,6 +26,11 @@ public class OpenaiChatResponseSpecification(
         apply {
             this.finishReason =
                 finishReason
+        }
+
+    public fun delayMillis(value: Long): OpenaiChatResponseSpecification =
+        apply {
+            this.delay = value.milliseconds
         }
 }
 

--- a/ai-mocks-openai/src/jvmTest/java/me/kpavlov/aimocks/openai/MockOpenaiJavaTest.java
+++ b/ai-mocks-openai/src/jvmTest/java/me/kpavlov/aimocks/openai/MockOpenaiJavaTest.java
@@ -47,6 +47,7 @@ class MockOpenaiJavaTest {
         }).responds(response -> {
             response.assistantContent("Hello");
             response.finishReason("stop");
+            response.delayMillis(42);
         });
 
         final var params = ChatCompletionCreateParams.builder()

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/lc4j/ChatCompletionLc4jTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/lc4j/ChatCompletionLc4jTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.test.runTest
 import me.kpavlov.aimocks.openai.AbstractMockOpenaiTest
 import me.kpavlov.aimocks.openai.openai
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
 
 internal class ChatCompletionLc4jTest : AbstractMockOpenaiTest() {
     private val model: OpenAiChatModel =
@@ -31,6 +32,7 @@ internal class ChatCompletionLc4jTest : AbstractMockOpenaiTest() {
             } responds {
                 assistantContent = "Hello"
                 finishReason = "stop"
+                delay = 42.milliseconds
             }
 
             val result =

--- a/docs/config/_default/menus/menu.en.toml
+++ b/docs/config/_default/menus/menu.en.toml
@@ -7,7 +7,7 @@ url = "docs/"
 [[main]]
   name = "API Reference"
   weight = 3
-  url = "https://kpavlov.github.io/ai-mocks/ai-mocks/api/"
+  url = "https://kpavlov.github.io/ai-mocks/api/"
 
 [[main]]
   name = "GitHub"

--- a/docs/config/_default/params.toml
+++ b/docs/config/_default/params.toml
@@ -6,7 +6,7 @@ repo = "https://github.com/kpavlov/ai-mocks"
 
 # Defaults to true if not set
 # Enable copyRight Footer Stamp. Takes in attribution
-enableCopyright = false
+enableCopyright = true
 
 # search
 [search]

--- a/docs/content/docs/ai-mocks/openai.md
+++ b/docs/content/docs/ai-mocks/openai.md
@@ -50,6 +50,7 @@ openai.completion {
 } responds {
   assistantContent = "Hello"
   finishReason = "stop"
+  delay = 42.milliseconds // delay before answer
 }
 
 // OpenAI client setup


### PR DESCRIPTION
Add support to customize response delays in OpenAI mocks. A `delayMillis` utility is introduced, allowing developers to specify a delay before responses are returned.

