### PR TITLE
Add string containment matchers and tests

### DIFF
--- a/ai-mocks-core/build.gradle.kts
+++ b/ai-mocks-core/build.gradle.kts
@@ -12,5 +12,10 @@ kotlin {
                 api(project(":mokksy"))
             }
         }
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 }

--- a/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/ChatRequestSpecification.kt
+++ b/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/ChatRequestSpecification.kt
@@ -2,6 +2,9 @@ package me.kpavlov.aimocks.core
 
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.string.contain
+import io.kotest.matchers.string.containIgnoringCase
+import me.kpavlov.mokksy.kotest.doesNotContain
+import me.kpavlov.mokksy.kotest.doesNotContainIgnoringCase
 
 public abstract class ChatRequestSpecification<P>(
     public var temperature: Double? = null,
@@ -27,6 +30,43 @@ public abstract class ChatRequestSpecification<P>(
     public fun requestBodyContains(substring: String): ChatRequestSpecification<P> =
         apply {
             requestBodyString += contain(substring)
+        }
+
+    /**
+     * Adds a condition to ensure the request body contains the specified substring,
+     * ignoring case sensitivity.
+     *
+     * @param substring The substring that the request body should contain, case-insensitive.
+     * @return The current instance of ChatRequestSpecification with the updated condition.
+     */
+    public fun requestBodyContainsIgnoringCase(substring: String): ChatRequestSpecification<P> =
+        apply {
+            requestBodyString += containIgnoringCase(substring)
+        }
+
+    /**
+     * Adds a condition to ensure the request body contains the specified substring,
+     * ignoring case sensitivity.
+     *
+     * @param substring The substring that the request body should contain, case-insensitive.
+     * @return The current instance of ChatRequestSpecification with the updated condition.
+     */
+    public fun requestBodyDoesNotContainsIgnoringCase(
+        substring: String,
+    ): ChatRequestSpecification<P> =
+        apply {
+            requestBodyString += doesNotContainIgnoringCase(substring)
+        }
+
+    /**
+     * Adds a condition to ensure the request body contains the specified substring.
+     *
+     * @param substring The substring that the request body should contain, case-sensitive.
+     * @return The current instance of ChatRequestSpecification with the updated condition.
+     */
+    public fun requestBodyDoesNotContains(substring: String): ChatRequestSpecification<P> =
+        apply {
+            requestBodyString += doesNotContain(substring)
         }
 
     /**

--- a/ai-mocks-core/src/commonTest/kotlin/me/kpavlov/aimocks/core/ChatRequestSpecificationTest.kt
+++ b/ai-mocks-core/src/commonTest/kotlin/me/kpavlov/aimocks/core/ChatRequestSpecificationTest.kt
@@ -1,0 +1,56 @@
+package me.kpavlov.aimocks.core
+
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class ChatRequestSpecificationTest {
+    lateinit var subject: ChatRequestSpecification<String>
+
+    @BeforeTest
+    fun before() {
+        subject =
+            object : ChatRequestSpecification<String>() {
+                override fun systemMessageContains(substring: String) = TODO()
+
+                override fun userMessageContains(substring: String) = TODO()
+            }
+    }
+
+    @Test
+    fun requestBodyDoesNotContainsIgnoringCase() {
+        subject.requestBodyDoesNotContainsIgnoringCase("hello world")
+
+        subject.requestBodyString.first().let {
+            it.test("Bye Space") shouldNotBeNull {
+                passed() shouldBe true
+            }
+            it.test("so, hello world etc") shouldNotBeNull {
+                passed() shouldBe false
+                failureMessage() shouldBe
+                    "\"so, hello world etc\" should not contain the substring \"hello world\" (case insensitive)"
+                negatedFailureMessage() shouldBe
+                    "\"so, hello world etc\" should contain the substring \"hello world\" (case insensitive)"
+            }
+        }
+    }
+
+    @Test
+    fun requestBodyDoesNotContains() {
+        subject.requestBodyDoesNotContains("hello world")
+
+        subject.requestBodyString.first().let {
+            it.test("so, hello world etc") shouldNotBeNull {
+                passed() shouldBe false
+                failureMessage() shouldBe
+                    "\"so, hello world etc\" should not contain the substring \"hello world\" (case sensitive)"
+                negatedFailureMessage() shouldBe
+                    "\"so, hello world etc\" should contain the substring \"hello world\" (case sensitive)"
+            }
+            it.test("hello people and world") shouldNotBeNull {
+                passed() shouldBe true
+            }
+        }
+    }
+}

--- a/ai-mocks-openai/build.gradle.kts
+++ b/ai-mocks-openai/build.gradle.kts
@@ -78,6 +78,7 @@ kotlin {
 
         commonTest {
             dependencies {
+                implementation(kotlin("test"))
                 implementation(libs.assertk)
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.kotlinLogging)

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/kotest/Matchers.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/kotest/Matchers.kt
@@ -1,0 +1,48 @@
+package me.kpavlov.mokksy.kotest
+
+import io.kotest.assertions.print.print
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+
+/**
+ * Creates a matcher that checks if a given string does not contain the specified substring,
+ * ignoring case sensitivity.
+ *
+ * The check also supports null values, treating them as not containing any substring.
+ *
+ * @param substr The substring to check for, ignoring case sensitivity.
+ * @return A Matcher instance that evaluates the given condition.
+ */
+public fun doesNotContainIgnoringCase(substr: String): Matcher<String?> =
+    Matcher<String?> { value ->
+        MatcherResult(
+            value == null || value.lowercase().indexOf(substr.lowercase()) == -1,
+            {
+                "${value.print().value} should not contain the substring ${substr.print().value} (case insensitive)"
+            },
+            {
+                "${value.print().value} should contain the substring ${substr.print().value} (case insensitive)"
+            },
+        )
+    }
+
+/**
+ * Creates a matcher that checks if a given string does not contain the specified substring.
+ *
+ * The check also supports null values, treating them as not containing any substring.
+ *
+ * @param substr The substring to check for.
+ * @return A Matcher instance that evaluates the given condition.
+ */
+public fun doesNotContain(substr: String): Matcher<String?> =
+    Matcher<String?> { value ->
+        MatcherResult(
+            value == null || value.indexOf(substr) == -1,
+            {
+                "${value.print().value} should not contain the substring ${substr.print().value} (case sensitive)"
+            },
+            {
+                "${value.print().value} should contain the substring ${substr.print().value} (case sensitive)"
+            },
+        )
+    }


### PR DESCRIPTION
This pull request introduces new matchers `doesNotContain` and `doesNotContainIgnoringCase` to `mokksy`, as well as corresponding methods in `ChatRequestSpecification` for case-sensitive and case-insensitive string containment checks. These enhancements include comprehensive tests to ensure functionality and reliability.