### PR TITLE
Refactor stopReason to use unified StopReason class

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           gradle-version: 8.13
           add-job-summary-as-pr-comment: on-failure # Valid values are 'never' (default), 'always', and 'on-failure'
+          cache-cleanup: 'always'
 
       - name: Build with Gradle
         run: gradle --no-daemon clean build dokkaGenerate koverXmlReport

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,7 +41,7 @@ jobs:
           add-job-summary-as-pr-comment: on-failure # Valid values are 'never' (default), 'always', and 'on-failure'
 
       - name: Build with Gradle
-        run: gradle --no-daemon build dokkaGenerate koverXmlReport
+        run: gradle --no-daemon clean build dokkaGenerate koverXmlReport
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5

--- a/ai-mocks-anthropic/src/commonMain/kotlin/me/kpavlov/aimocks/anthropic/AnthropicBuildingStep.kt
+++ b/ai-mocks-anthropic/src/commonMain/kotlin/me/kpavlov/aimocks/anthropic/AnthropicBuildingStep.kt
@@ -5,6 +5,7 @@ import com.anthropic.models.messages.ContentBlock
 import com.anthropic.models.messages.Message
 import com.anthropic.models.messages.MessageCreateParams
 import com.anthropic.models.messages.MessageParam
+import com.anthropic.models.messages.StopReason
 import com.anthropic.models.messages.TextBlock
 import com.anthropic.models.messages.Usage
 import io.ktor.sse.ServerSentEvent
@@ -64,7 +65,7 @@ public class AnthropicBuildingStep(
                             ),
                         ),
                     ).stopSequence(null)
-                    .stopReason(Message.StopReason.of(stopReason))
+                    .stopReason(StopReason.of(stopReason))
                     .usage(
                         Usage
                             .builder()

--- a/ai-mocks-anthropic/src/commonMain/kotlin/me/kpavlov/aimocks/anthropic/StreamingResponseHelper.kt
+++ b/ai-mocks-anthropic/src/commonMain/kotlin/me/kpavlov/aimocks/anthropic/StreamingResponseHelper.kt
@@ -9,6 +9,7 @@ import com.anthropic.models.messages.RawContentBlockStopEvent
 import com.anthropic.models.messages.RawMessageDeltaEvent
 import com.anthropic.models.messages.RawMessageStartEvent
 import com.anthropic.models.messages.RawMessageStopEvent
+import com.anthropic.models.messages.StopReason
 import com.anthropic.models.messages.TextBlock
 import com.anthropic.models.messages.Usage
 import io.ktor.sse.ServerSentEvent
@@ -112,7 +113,7 @@ internal object StreamingResponseHelper {
                 .delta(
                     RawMessageDeltaEvent.Delta
                         .builder()
-                        .stopReason(RawMessageDeltaEvent.Delta.StopReason.of(stopReason))
+                        .stopReason(StopReason.of(stopReason))
                         .stopSequence(Optional.empty())
                         .build(),
                 ).usage(

--- a/ai-mocks-anthropic/src/commonMain/kotlin/me/kpavlov/aimocks/anthropic/StreamingResponseHelper.kt
+++ b/ai-mocks-anthropic/src/commonMain/kotlin/me/kpavlov/aimocks/anthropic/StreamingResponseHelper.kt
@@ -132,6 +132,7 @@ internal object StreamingResponseHelper {
         val data =
             RawContentBlockStopEvent
                 .builder()
+                .index(0)
                 .build()
         return ServerSentEvent(
             event = data._type().asStringOrThrow(),

--- a/ai-mocks-anthropic/src/jvmTest/kotlin/me/kpavlov/aimocks/anthropic/official/AnthropicSdkStreamingMessagesTest.kt
+++ b/ai-mocks-anthropic/src/jvmTest/kotlin/me/kpavlov/aimocks/anthropic/official/AnthropicSdkStreamingMessagesTest.kt
@@ -3,6 +3,7 @@ package me.kpavlov.aimocks.anthropic.official
 import com.anthropic.models.messages.MessageCreateParams
 import com.anthropic.models.messages.Metadata
 import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
 import kotlinx.coroutines.flow.count
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
@@ -20,7 +21,7 @@ internal class AnthropicSdkStreamingMessagesTest : AbstractAnthropicTest() {
     @Test
     fun `Should respond to Streaming Messages Completion with chunk list`() =
         runTest {
-            anthropic.messages("openai-completion-list") {
+            anthropic.messages("anthropic-messages-list") {
                 temperature = temperatureValue
                 model = modelName
                 userId = userIdValue
@@ -37,7 +38,7 @@ internal class AnthropicSdkStreamingMessagesTest : AbstractAnthropicTest() {
     @Test
     fun `Should respond to Streaming Chat Completion with Flow`() =
         runTest {
-            anthropic.messages("openai-completion-flow") {
+            anthropic.messages("anthropic-messages-flow") {
                 temperature = temperatureValue
                 model = modelName
                 userId = userIdValue
@@ -52,7 +53,7 @@ internal class AnthropicSdkStreamingMessagesTest : AbstractAnthropicTest() {
                     }
                 delay = 60.milliseconds
                 delayBetweenChunks = 15.milliseconds
-                stopReason = "stop"
+                stopReason = "end_turn"
             }
 
             verifyStreamingCall()
@@ -85,6 +86,6 @@ internal class AnthropicSdkStreamingMessagesTest : AbstractAnthropicTest() {
                     .count()
             }
         timedValue.duration shouldBeLessThan 10.seconds
-        timedValue.value shouldBeLessThan 10
+        timedValue.value shouldBeLessThanOrEqual 10
     }
 }


### PR DESCRIPTION
This pull request focuses on refactoring the usage of the `StopReason` class within the `ai-mocks-anthropic` module. The primary changes involve updating import statements and modifying method calls to use the `StopReason` class directly.

Refactoring for `StopReason` class:

* [`ai-mocks-anthropic/src/commonMain/kotlin/me/kpavlov/aimocks/anthropic/AnthropicBuildingStep.kt`](diffhunk://#diff-74fe6047b63f7e751dc4521b6f1baa0fd5a137afc50195aade96571f1c103206R8): Updated the import statement to include `StopReason` and modified the `stopReason` method call to use `StopReason.of(stopReason)` directly. [[1]](diffhunk://#diff-74fe6047b63f7e751dc4521b6f1baa0fd5a137afc50195aade96571f1c103206R8) [[2]](diffhunk://#diff-74fe6047b63f7e751dc4521b6f1baa0fd5a137afc50195aade96571f1c103206L67-R68)
* [`ai-mocks-anthropic/src/commonMain/kotlin/me/kpavlov/aimocks/anthropic/StreamingResponseHelper.kt`](diffhunk://#diff-0abb18375045b3d2dc9b14a616af1f69b7fac5be36556dad2a7d0cb84ab3f2f9R12): Updated the import statement to include `StopReason` and modified the `stopReason` method call to use `StopReason.of(stopReason)` directly. [[1]](diffhunk://#diff-0abb18375045b3d2dc9b14a616af1f69b7fac5be36556dad2a7d0cb84ab3f2f9R12) [[2]](diffhunk://#diff-0abb18375045b3d2dc9b14a616af1f69b7fac5be36556dad2a7d0cb84ab3f2f9L115-R116)