### PR TITLE
Add matchers for filename and request body predicates

### DIFF
--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesMatchers.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesMatchers.kt
@@ -23,8 +23,7 @@ internal object OpenaiResponsesMatchers {
             override fun test(value: CreateResponseRequest?): MatcherResult =
                 MatcherResult(
                     value != null &&
-                        value.instructions
-                            ?.contains(string) == true,
+                        value.instructions?.contains(string) == true,
                     { "Instructions should contain \"$string\"" },
                     { "Instructions should not contain \"$string\"" },
                 )

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesMatchers.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesMatchers.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import me.kpavlov.aimocks.openai.model.responses.CreateResponseRequest
 import me.kpavlov.aimocks.openai.model.responses.InputContent
+import me.kpavlov.aimocks.openai.model.responses.InputFile
 import me.kpavlov.aimocks.openai.model.responses.InputImage
 import me.kpavlov.aimocks.openai.model.responses.InputItems
 import me.kpavlov.aimocks.openai.model.responses.InputText
@@ -60,12 +61,35 @@ internal object OpenaiResponsesMatchers {
 
                 return MatcherResult(
                     passed,
-                    { "Instructions should contain \"$imageUrl\"" },
-                    { "Instructions should not contain \"$imageUrl\"" },
+                    { "Input should contain image with url \"$imageUrl\"" },
+                    { "Input should NOT contain image with url \"$imageUrl\"" },
                 )
             }
 
             override fun toString(): String = "InputImage should have URL \"$imageUrl\""
+        }
+
+    fun containsInputFileWithNamed(filename: String): Matcher<CreateResponseRequest?> =
+        object : Matcher<CreateResponseRequest?> {
+            override fun test(value: CreateResponseRequest?): MatcherResult {
+                val passed =
+                    if (value == null) {
+                        false
+                    } else if ((value.input is InputItems) == false) {
+                        false
+                    } else {
+                        val files = extractInputItem<InputFile>(value)
+                        files?.any { it.filename == filename } == true
+                    }
+
+                return MatcherResult(
+                    passed,
+                    { "Request should contain file named \"$filename\"" },
+                    { "Request should NOT contain file named  \"$filename\"" },
+                )
+            }
+
+            override fun toString(): String = "Request should contain file named \"$filename\""
         }
 
     fun userMessageContains(subString: String): Matcher<CreateResponseRequest?> =

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesRequestSpecification.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesRequestSpecification.kt
@@ -36,6 +36,15 @@ public open class OpenaiResponsesRequestSpecification(
     }
 
     /**
+     * Checks if the input contains a file with the specified filename.
+     *
+     * @param filename The name of the file to check for in the input.
+     */
+    public fun containsInputFileWithNamed(filename: String) {
+        requestBody.add(OpenaiResponsesMatchers.containsInputFileWithNamed(filename))
+    }
+
+    /**
      * Checks if the input includes an image with the specified URL.
      *
      * @param imageUrl The URL of the image to check for in the input. Might be Base64 image url

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesFileInputTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesFileInputTest.kt
@@ -1,0 +1,111 @@
+package me.kpavlov.aimocks.openai.official.responses
+
+import com.openai.models.responses.EasyInputMessage
+import com.openai.models.responses.ResponseCreateParams
+import com.openai.models.responses.ResponseInputContent
+import com.openai.models.responses.ResponseInputFile
+import com.openai.models.responses.ResponseInputItem
+import com.openai.models.responses.ResponseInputText
+import io.kotest.matchers.string.shouldContainIgnoringCase
+import io.kotest.matchers.string.shouldStartWith
+import me.kpavlov.aimocks.openai.official.AbstractOpenaiTest
+import me.kpavlov.aimocks.openai.openai
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.net.URL
+import java.util.UUID
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.time.measureTimedValue
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class ResponsesFileInputTest : AbstractOpenaiTest() {
+    private lateinit var imageResource: URL
+    private lateinit var filename: String
+    private lateinit var fileId: String
+
+    @OptIn(ExperimentalEncodingApi::class)
+    @BeforeAll
+    fun beforeAll() {
+        imageResource = this.javaClass.getResource("/pipiro.jpg")!!
+        filename = imageResource.file
+        fileId = UUID.randomUUID().toString()
+    }
+
+    @Test
+    @Suppress("LongMethod")
+    fun `Should match file`() {
+        modelName = "gpt-4o-mini" // cheap model
+        openai.responses {
+            temperature = temperatureValue
+            model = modelName
+
+            containsInputFileWithNamed(filename)
+        } responds {
+            assistantContent = "The file is an image."
+        }
+
+        val input =
+            ResponseCreateParams.Input.ofResponse(
+                listOf(
+                    ResponseInputItem.Companion.ofEasyInputMessage(
+                        EasyInputMessage.Companion
+                            .builder()
+                            .role(EasyInputMessage.Role.USER)
+                            .content(
+                                EasyInputMessage.Content.Companion
+                                    .ofResponseInputMessageContentList(
+                                        listOf(
+                                            ResponseInputContent.Companion.ofInputText(
+                                                ResponseInputText.Companion
+                                                    .builder()
+                                                    .text(
+                                                        "what's the file?",
+                                                    ).build(),
+                                            ),
+                                            ResponseInputContent.Companion.ofInputFile(
+                                                ResponseInputFile.Companion
+                                                    .builder()
+                                                    .fileId(fileId)
+                                                    .filename(filename)
+                                                    .build(),
+                                            ),
+                                        ),
+                                    ),
+                            ).build(),
+                    ),
+                ),
+            )
+        val params =
+            ResponseCreateParams.Companion
+                .builder()
+                .temperature(temperatureValue)
+                .maxOutputTokens(maxCompletionTokensValue)
+                .model(modelName)
+                .instructions("You are a file expert")
+                .input(input)
+                .build()
+
+        val timedValue =
+            measureTimedValue {
+                client.responses().create(params)
+            }
+
+        val response = timedValue.value
+
+        logger.debug { "Response: $response" }
+        val message = response.output().first().asMessage()
+
+        val assistantText =
+            message
+                .content()
+                .first()
+                .asOutputText()
+                .text()
+        logger.info { "Assistant text: $assistantText" }
+
+        assistantText shouldContainIgnoringCase "image"
+
+        response.model().asString() shouldStartWith modelName
+    }
+}

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/RequestMarchers.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/RequestMarchers.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import io.ktor.http.Headers
+import java.util.function.Predicate
 
 /**
  * Custom matcher to verify that the Ktor [Headers] object contains a header with the specified name and value.
@@ -41,3 +42,26 @@ public infix fun Headers.shouldHaveHeader(header: Pair<String, String>) {
 public infix fun Headers.shouldNotHaveHeader(header: Pair<String, String>) {
     this shouldNot containsHeader(header.first, header.second)
 }
+
+/**
+ * Creates a matcher that evaluates objects against a specified predicate.
+ *
+ * @param T the type of the object being matched
+ * @param predicate the predicate to evaluate objects against
+ * @return a [Matcher] that applies the given predicate to objects for evaluation
+ */
+internal fun <T> predicateMatcher(predicate: Predicate<T?>): Matcher<T?> =
+    object : Matcher<T?> {
+        override fun test(value: T?): MatcherResult =
+            MatcherResult(
+                predicate.test(value),
+                {
+                    "Object '$value' should match predicate '$predicate'"
+                },
+                {
+                    "Object '$value' should NOT match predicate '$predicate'"
+                },
+            )
+
+        override fun toString(): String = "PredicateMatcher($predicate)"
+    }

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/RequestMarchers.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/RequestMarchers.kt
@@ -5,7 +5,6 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import io.ktor.http.Headers
-import java.util.function.Predicate
 
 /**
  * Custom matcher to verify that the Ktor [Headers] object contains a header with the specified name and value.
@@ -50,11 +49,11 @@ public infix fun Headers.shouldNotHaveHeader(header: Pair<String, String>) {
  * @param predicate the predicate to evaluate objects against
  * @return a [Matcher] that applies the given predicate to objects for evaluation
  */
-internal fun <T> predicateMatcher(predicate: Predicate<T?>): Matcher<T?> =
+internal fun <T> predicateMatcher(predicate: (T?) -> Boolean): Matcher<T?> =
     object : Matcher<T?> {
         override fun test(value: T?): MatcherResult =
             MatcherResult(
-                predicate.test(value),
+                predicate.invoke(value),
                 {
                     "Object '$value' should match predicate '$predicate'"
                 },

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/RequestSpecification.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/RequestSpecification.kt
@@ -13,7 +13,6 @@ import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
 import io.ktor.server.request.receive
 import io.ktor.server.request.receiveText
-import java.util.function.Predicate
 import kotlin.reflect.KClass
 
 /**
@@ -182,7 +181,7 @@ public open class RequestSpecificationBuilder<P : Any>(
      * @return The same instance of [RequestSpecificationBuilder] with the predicate applied
      *         for further customization.
      */
-    public fun bodyMatchesPredicate(predicate: Predicate<P?>): RequestSpecificationBuilder<P> {
+    public fun bodyMatchesPredicate(predicate: (P?) -> Boolean): RequestSpecificationBuilder<P> {
         this.body += predicateMatcher<P?>(predicate)
         return this
     }
@@ -197,7 +196,7 @@ public open class RequestSpecificationBuilder<P : Any>(
      *         for further customization.
      */
     public fun bodyMatchesPredicates(
-        vararg predicate: Predicate<P?>,
+        vararg predicate: (P?) -> Boolean,
     ): RequestSpecificationBuilder<P> {
         predicate.forEach { bodyMatchesPredicate(it) }
         return this

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/RequestSpecification.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/RequestSpecification.kt
@@ -1,6 +1,7 @@
 package me.kpavlov.mokksy.request
 
 import io.kotest.matchers.Matcher
+import io.kotest.matchers.equals.beEqual
 import io.kotest.matchers.string.contain
 import io.ktor.http.Headers
 import io.ktor.http.HttpMethod
@@ -12,6 +13,7 @@ import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
 import io.ktor.server.request.receive
 import io.ktor.server.request.receiveText
+import java.util.function.Predicate
 import kotlin.reflect.KClass
 
 /**
@@ -160,8 +162,44 @@ public open class RequestSpecificationBuilder<P : Any>(
         return this
     }
 
+    public fun path(pathString: String): RequestSpecificationBuilder<P> {
+        this.path = beEqual(pathString)
+        return this
+    }
+
     public fun bodyContains(vararg strings: String): RequestSpecificationBuilder<P> {
         strings.forEach { this.bodyString += contain(it) }
+        return this
+    }
+
+    /**
+     * Adds a predicate to match against the request body.
+     *
+     * The specified predicate will be used to evaluate whether the request body satisfies the defined condition.
+     *
+     * @param predicate The predicate used to evaluate the request body. It defines the condition
+     *                  that the request body must satisfy.
+     * @return The same instance of [RequestSpecificationBuilder] with the predicate applied
+     *         for further customization.
+     */
+    public fun bodyMatchesPredicate(predicate: Predicate<P?>): RequestSpecificationBuilder<P> {
+        this.body += predicateMatcher<P?>(predicate)
+        return this
+    }
+
+    /**
+     * Adds multiple predicates to match against the request body.
+     * Each predicate will be applied to evaluate whether the request body satisfies the specified conditions.
+     *
+     * @param predicate A variable number of predicates to evaluate the request body.
+     *                  All predicates are added as matchers for the request body.
+     * @return The same instance of [RequestSpecificationBuilder] with the predicates applied
+     *         for further customization.
+     */
+    public fun bodyMatchesPredicates(
+        vararg predicate: Predicate<P?>,
+    ): RequestSpecificationBuilder<P> {
+        predicate.forEach { bodyMatchesPredicate(it) }
         return this
     }
 

--- a/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/request/RequestMarchersKtTest.kt
+++ b/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/request/RequestMarchersKtTest.kt
@@ -1,0 +1,31 @@
+package me.kpavlov.mokksy.request
+
+import io.kotest.matchers.shouldBe
+import me.kpavlov.mokksy.Input
+import org.junit.jupiter.api.Test
+
+class RequestMarchersKtTest {
+    private val predicate: (Input?) -> Boolean =
+        object : (Input?) -> Boolean {
+            override fun invoke(p1: Input?): Boolean = (p1?.name == "foo") == true
+
+            override fun toString(): String = "predicateToString"
+        }
+
+    @Test
+    fun `Should test predicate matcher`() {
+        val input = Input("foo")
+
+        predicateMatcher<Input>(predicate)
+            .apply {
+                toString() shouldBe "PredicateMatcher(predicateToString)"
+                test(input).apply {
+                    passed() shouldBe true
+                    failureMessage() shouldBe
+                        "Object 'Input(name=foo)' should match predicate 'predicateToString'"
+                    negatedFailureMessage() shouldBe
+                        "Object 'Input(name=foo)' should NOT match predicate 'predicateToString'"
+                }
+            }
+    }
+}

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/BodyMatchingIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/BodyMatchingIT.kt
@@ -1,0 +1,65 @@
+package me.kpavlov.mokksy
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.random.Random
+import kotlin.test.BeforeTest
+
+@Suppress("UastIncorrectHttpHeaderInspection")
+internal class BodyMatchingIT : AbstractIT() {
+    private lateinit var name: String
+
+    private lateinit var requestPayload: TestPerson
+
+    @BeforeTest
+    fun before() {
+        name = UUID.randomUUID().toString()
+
+        requestPayload = TestPerson.random()
+    }
+
+    @Test
+    fun `Should match body predicate`() =
+        runTest {
+            // given
+            val id = Random.nextInt().toString()
+            val expectedResponse = TestPerson.random()
+
+            mokksy
+                .post<Input>(name = "predicate", Input::class) {
+                    path("/predicate")
+
+                    bodyMatchesPredicate {
+                        it?.name?.contains(id) == true
+                    }
+
+                    bodyMatchesPredicates({
+                        it?.name?.isNotBlank() == true
+                    })
+                }.respondsWith(TestPerson::class) {
+                    body = expectedResponse
+                    httpStatus = HttpStatusCode.Created
+                    headers += "Foo" to "bar" // list style
+                }
+            // when
+            val result =
+                client.post("/predicate") {
+                    contentType(ContentType.Application.Json)
+                    setBody(Json.encodeToString(Input(id)))
+                }
+
+            // then
+            result.status shouldBe HttpStatusCode.Created
+            result.bodyAsText() shouldBe Json.encodeToString(expectedResponse)
+            result.headers["Foo"] shouldBe "bar"
+        }
+}


### PR DESCRIPTION
# Summary

This Pull Request adds functionality for matching and testing specific conditions in request inputs. It improves the matcher utilities, enhances flexibility for input validation, and introduces new test cases for the added features.

## New matchers added:
- `containsInputFileWithNamed` matcher for verifying input files by name.
- Predicate-based matchers (predicateMatcher) for evaluating objects against custom conditions.
- Support for adding single or multiple predicates to match request bodies.

## Enhancements to request specification:
- Added bodyMatchesPredicate and bodyMatchesPredicates for advanced request body validation.
- Ability to match request paths with pathString.

## Testing improvements:
- Added unit and integration tests for new matchers, including ResponsesFileInputTest, RequestMarchersKtTest, and BodyMatchingIT.
- Comprehensive scenarios added for validating requests with custom predicates, file inputs, and body content.