### PR TITLE
Fix tool_choice value in OpenAPI Responses API

### DIFF
--- a/ai-mocks-openai/build.gradle.kts
+++ b/ai-mocks-openai/build.gradle.kts
@@ -44,21 +44,22 @@ openApiGenerate {
         mapOf(
             "models" to // generate only models
                 listOf(
+                    "Annotation",
                     "ChatCompletionRole",
                     "ChatCompletionStreamOptions",
                     "Error",
-                    "Refusal",
-                    "ResponsePropertiesToolChoice",
-                    "Reasoning",
-                    "ReasoningEffort",
-                    "OutputMessage",
-                    "OutputContent",
-                    "OutputText",
-                    "Annotation",
                     "FileCitation",
                     "FilePath",
+                    "OutputContent",
+                    "OutputMessage",
+                    "OutputText",
+                    "Reasoning",
+                    "Reasoning",
+                    "ReasoningEffort",
+                    "Refusal",
+                    "ResponseError",
+                    "ResponseErrorCode",
                     "UrlCitation",
-                    "ResponsePropertiesToolChoice",
                 ).joinToString(","),
         ),
     )
@@ -67,7 +68,6 @@ openApiGenerate {
             "enumPropertyNaming" to "UPPERCASE",
             "dateLibrary" to "kotlinx-datetime",
             "explicitApi" to "true",
-//            "modelMutable" to "true",
         ),
     )
 }

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/model/responses/ResponseModels.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/model/responses/ResponseModels.kt
@@ -22,6 +22,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import me.kpavlov.aimocks.openai.model.OutputMessage
 import me.kpavlov.aimocks.openai.model.Reasoning
+import me.kpavlov.aimocks.openai.model.ResponseError
 import me.kpavlov.aimocks.openai.model.chat.Tool
 
 /**
@@ -87,6 +88,7 @@ internal object InputSerializer : JsonContentPolymorphicSerializer<Input>(Input:
         when {
             element is JsonPrimitive && element.isString
             -> Text.serializer()
+
             else -> InputItems.serializer()
         }
 }
@@ -178,6 +180,10 @@ public data class Response
         @SerialName(value = "truncation") val truncation: Truncation? = Truncation.DISABLED,
         @SerialName(value = "status") val status: Status? = null,
         @SerialName(value = "output_text") val outputText: String? = null,
+        @SerialName(value = "incomplete_details") val incompleteDetails: IncompleteDetails? = null,
+        @SerialName(value = "usage") val usage: Usage,
+        @EncodeDefault(ALWAYS)
+        @SerialName(value = "error") val error: ResponseError? = null,
     ) {
         /**
          * The status of the response generation.
@@ -201,6 +207,48 @@ public data class Response
             INCOMPLETE("incomplete"),
         }
     }
+
+/**
+ * Represents token usage details including input tokens, output tokens,
+ * a breakdown of output tokens, and the total tokens used.
+ *
+ * @param inputTokens The number of input tokens.
+ * @param inputTokensDetails
+ * @param outputTokens The number of output tokens.
+ * @param outputTokensDetails
+ * @param totalTokens The total number of tokens used.
+ */
+@Serializable
+public data class Usage(
+    // The number of input tokens.
+    @SerialName(value = "input_tokens") @Required val inputTokens: Int,
+    @SerialName(value = "input_tokens_details") @Required val inputTokensDetails:
+        InputTokensDetails,
+    // The number of output tokens.
+    @SerialName(value = "output_tokens") @Required val outputTokens: Int,
+    @SerialName(value = "output_tokens_details") @Required val outputTokensDetails:
+        OutputTokensDetails,
+    // The total number of tokens used.
+    @SerialName(value = "total_tokens") @Required val totalTokens: Int,
+)
+
+@Serializable
+public data class InputTokensDetails(
+    @SerialName(value = "cached_tokens") @Required val cachedTokens: Int,
+)
+
+@Serializable
+public data class OutputTokensDetails(
+    @SerialName(value = "reasoning_tokens") @Required val reasoningTokens: Int,
+)
+
+/**
+ * Details about why the response is incomplete.
+ */
+@Serializable
+public data class IncompleteDetails(
+    val reason: String,
+)
 
 /**
  * The truncation strategy to use for the model response.

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/model/responses/ResponseModels.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/model/responses/ResponseModels.kt
@@ -162,7 +162,7 @@ public data class Response
         @SerialName(value = "instructions") @Required val instructions: String?,
         @SerialName(value = "tools") @Required val tools: List<Tool> = emptyList(),
         @SerialName(value = "tool_choice")
-        @Required val toolChoice: Map<String, String> = emptyMap(),
+        @Required val toolChoice: String = "auto",
         @SerialName(value = "id") @Required val id: String,
         @EncodeDefault(ALWAYS)
         @SerialName("object")

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesBuildingStep.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesBuildingStep.kt
@@ -30,6 +30,7 @@ public class OpenaiResponsesBuildingStep(
     ) {
     private var counter: AtomicInteger = AtomicInteger(1)
 
+    @OptIn(ExperimentalStdlibApi::class)
     @Suppress("MagicNumber")
     public override infix fun responds(block: OpenaiResponsesResponseSpecification.() -> Unit) {
         buildingStep.respondsWith {
@@ -50,12 +51,12 @@ public class OpenaiResponsesBuildingStep(
 
             body =
                 Response(
-                    id = "chatcmpl-abc${counter.addAndGet(1)}",
+                    id = "resp_${counter.addAndGet(1).toHexString()}",
                     model = request.model,
                     metadata = null,
                     instructions = null,
                     tools = emptyList(),
-                    toolChoice = emptyMap(),
+                    toolChoice = "auto",
                     createdAt = Instant.now().epochSecond,
 //                    error = null,
 //                    incompleteDetails = null,

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesBuildingStep.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesBuildingStep.kt
@@ -4,7 +4,10 @@ import me.kpavlov.aimocks.core.LlmBuildingStep
 import me.kpavlov.aimocks.openai.model.OutputContent
 import me.kpavlov.aimocks.openai.model.OutputMessage
 import me.kpavlov.aimocks.openai.model.responses.CreateResponseRequest
+import me.kpavlov.aimocks.openai.model.responses.InputTokensDetails
+import me.kpavlov.aimocks.openai.model.responses.OutputTokensDetails
 import me.kpavlov.aimocks.openai.model.responses.Response
+import me.kpavlov.aimocks.openai.model.responses.Usage
 import me.kpavlov.mokksy.BuildingStep
 import me.kpavlov.mokksy.MokksyServer
 import java.time.Instant
@@ -39,15 +42,11 @@ public class OpenaiResponsesBuildingStep(
             val chatResponseSpecification = OpenaiResponsesResponseSpecification(responseDefinition)
             block.invoke(chatResponseSpecification)
             val assistantContent = chatResponseSpecification.assistantContent
-            val finishReason = chatResponseSpecification.finishReason
             delay = chatResponseSpecification.delay
 
-            val promptTokens = Random.Default.nextInt(1, 200)
-            val completionTokens = Random.Default.nextInt(1, 1500)
-            val reasoningTokens = completionTokens / 3
-            val acceptedPredictionTokens = (completionTokens - reasoningTokens) / 2
-            val rejectedPredictionTokens =
-                completionTokens - reasoningTokens - acceptedPredictionTokens
+            val inputTokens = Random.Default.nextInt(1, 200)
+            val outputTokens = Random.Default.nextInt(1, request.maxOutputTokens ?: 1500)
+            val reasoningTokens = outputTokens / 3
 
             body =
                 Response(
@@ -58,8 +57,10 @@ public class OpenaiResponsesBuildingStep(
                     tools = emptyList(),
                     toolChoice = "auto",
                     createdAt = Instant.now().epochSecond,
-//                    error = null,
-//                    incompleteDetails = null,
+                    temperature = request.temperature,
+                    maxOutputTokens = request.maxOutputTokens,
+                    error = null,
+                    incompleteDetails = null,
                     output =
                         listOf(
                             OutputMessage(
@@ -77,6 +78,20 @@ public class OpenaiResponsesBuildingStep(
                                     ),
                                 status = OutputMessage.Status.COMPLETED,
                             ),
+                        ),
+                    usage =
+                        Usage(
+                            inputTokens = inputTokens,
+                            inputTokensDetails =
+                                InputTokensDetails(
+                                    cachedTokens = 0,
+                                ),
+                            outputTokens = outputTokens,
+                            outputTokensDetails =
+                                OutputTokensDetails(
+                                    reasoningTokens = reasoningTokens,
+                                ),
+                            totalTokens = inputTokens + outputTokens,
                         ),
                 )
         }

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesBuildingStep.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesBuildingStep.kt
@@ -33,7 +33,6 @@ public class OpenaiResponsesBuildingStep(
     ) {
     private var counter: AtomicInteger = AtomicInteger(1)
 
-    @OptIn(ExperimentalStdlibApi::class)
     @Suppress("MagicNumber")
     public override infix fun responds(block: OpenaiResponsesResponseSpecification.() -> Unit) {
         buildingStep.respondsWith {
@@ -50,7 +49,7 @@ public class OpenaiResponsesBuildingStep(
 
             body =
                 Response(
-                    id = "resp_${counter.addAndGet(1).toHexString()}",
+                    id = "resp_${Integer.toHexString(counter.addAndGet(1))}",
                     model = request.model,
                     metadata = null,
                     instructions = null,

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/AbstractMockOpenaiTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/AbstractMockOpenaiTest.kt
@@ -15,6 +15,7 @@ internal abstract class AbstractMockOpenaiTest {
     protected var maxCompletionTokensValue: Long = -1
     protected lateinit var modelName: String
     protected val logger = KotlinLogging.logger(name = this::class.simpleName!!)
+    protected lateinit var startTimestamp: java.time.Instant
 
     @BeforeEach
     fun beforeEach() {
@@ -24,6 +25,7 @@ internal abstract class AbstractMockOpenaiTest {
         topKValue = Random.nextLong(1, 42)
         temperatureValue = Random.nextDouble(0.0, 1.0)
         maxCompletionTokensValue = Random.nextLong(100, 500)
+        startTimestamp = java.time.Instant.now()
     }
 
     @AfterEach

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/AbstractOpenaiResponsesTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/AbstractOpenaiResponsesTest.kt
@@ -1,0 +1,35 @@
+package me.kpavlov.aimocks.openai.official.responses
+
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
+import io.kotest.matchers.longs.shouldBeLessThanOrEqual
+import io.kotest.matchers.longs.shouldBeNonNegative
+import io.kotest.matchers.longs.shouldBePositive
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import me.kpavlov.aimocks.openai.official.AbstractOpenaiTest
+
+internal abstract class AbstractOpenaiResponsesTest : AbstractOpenaiTest() {
+    protected fun verifyResponse(response: com.openai.models.responses.Response) {
+        response.id() shouldStartWith "resp_"
+
+        response
+            .model()
+            .chat()
+            .orElseThrow()
+            .asString() shouldBe modelName
+
+        response.temperature().orElseThrow() shouldBe temperatureValue
+        response.maxOutputTokens().orElseThrow() shouldBe maxCompletionTokensValue
+
+        response.createdAt() shouldBeGreaterThanOrEqualTo startTimestamp.epochSecond.toDouble()
+
+        response.usage() shouldBePresent {
+            it.outputTokens().shouldBeLessThanOrEqual(maxCompletionTokensValue)
+            it.outputTokens().shouldBePositive()
+            it.inputTokens().shouldBePositive()
+            it.inputTokensDetails().cachedTokens().shouldBeNonNegative()
+            it.outputTokensDetails().reasoningTokens().shouldBePositive()
+        }
+    }
+}

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesFileInputTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesFileInputTest.kt
@@ -9,8 +9,6 @@ import com.openai.models.responses.ResponseInputItem
 import com.openai.models.responses.ResponseInputText
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.string.shouldContainIgnoringCase
-import io.kotest.matchers.string.shouldStartWith
-import me.kpavlov.aimocks.openai.official.AbstractOpenaiTest
 import me.kpavlov.aimocks.openai.openai
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -22,7 +20,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.time.measureTimedValue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-internal class ResponsesFileInputTest : AbstractOpenaiTest() {
+internal class ResponsesFileInputTest : AbstractOpenaiResponsesTest() {
     private lateinit var imageResource: URL
     private lateinit var filename: String
     private lateinit var fileId: String
@@ -75,11 +73,7 @@ internal class ResponsesFileInputTest : AbstractOpenaiTest() {
 
         assistantText shouldContainIgnoringCase "image"
 
-        response
-            .model()
-            .chat()
-            .orElseThrow()
-            .asString() shouldStartWith modelName
+        verifyResponse(response)
     }
 
     @Test

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesFileInputTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesFileInputTest.kt
@@ -75,7 +75,11 @@ internal class ResponsesFileInputTest : AbstractOpenaiTest() {
 
         assistantText shouldContainIgnoringCase "image"
 
-        response.model().asString() shouldStartWith modelName
+        response
+            .model()
+            .chat()
+            .orElseThrow()
+            .asString() shouldStartWith modelName
     }
 
     @Test

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesImageInputTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesImageInputTest.kt
@@ -10,8 +10,6 @@ import com.openai.models.responses.ResponseInputItem.Companion.ofEasyInputMessag
 import com.openai.models.responses.ResponseInputText
 import io.kotest.matchers.resource.resourceAsBytes
 import io.kotest.matchers.string.shouldContainIgnoringCase
-import io.kotest.matchers.string.shouldStartWith
-import me.kpavlov.aimocks.openai.official.AbstractOpenaiTest
 import me.kpavlov.aimocks.openai.openai
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -27,7 +25,7 @@ private const val WIKIPEDIA_IMAGE_URL =
     "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
 
 @TestInstance(Lifecycle.PER_CLASS)
-internal class ResponsesImageInputTest : AbstractOpenaiTest() {
+internal class ResponsesImageInputTest : AbstractOpenaiResponsesTest() {
     private lateinit var base64Image: String
     private lateinit var imageResource: URL
     private lateinit var base64ImageUrl: String
@@ -128,10 +126,6 @@ internal class ResponsesImageInputTest : AbstractOpenaiTest() {
 
         assistantText shouldContainIgnoringCase "creature"
 
-        response
-            .model()
-            .chat()
-            .orElseThrow()
-            .asString() shouldStartWith modelName
+        verifyResponse(response)
     }
 }

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesImageInputTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesImageInputTest.kt
@@ -128,6 +128,10 @@ internal class ResponsesImageInputTest : AbstractOpenaiTest() {
 
         assistantText shouldContainIgnoringCase "creature"
 
-        response.model().asString() shouldStartWith modelName
+        response
+            .model()
+            .chat()
+            .orElseThrow()
+            .asString() shouldStartWith modelName
     }
 }

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesTextTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesTextTest.kt
@@ -3,13 +3,12 @@ package me.kpavlov.aimocks.openai.official.responses
 import com.openai.models.responses.ResponseCreateParams
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
-import me.kpavlov.aimocks.openai.official.AbstractOpenaiTest
 import me.kpavlov.aimocks.openai.openai
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTimedValue
 
-internal class ResponsesTextTest : AbstractOpenaiTest() {
+internal class ResponsesTextTest : AbstractOpenaiResponsesTest() {
     @Test
     fun `Should respond to Responses`() {
         openai.responses {
@@ -35,22 +34,17 @@ internal class ResponsesTextTest : AbstractOpenaiTest() {
             }
 
         timedValue.duration shouldBeGreaterThan 200.milliseconds
-        val result = timedValue.value
+        val response = timedValue.value
 
-        result.validate()
-
-        val message = result.output().first().asMessage()
+        val message = response.output().first().asMessage()
         logger.info { "Response message: $message" }
         message
             .content()
             .first()
             .asOutputText()
             .text() shouldBe "Find. Create. Sell."
-        result
-            .model()
-            .chat()
-            .orElseThrow()
-            .asString() shouldBe modelName
+
+        verifyResponse(response)
     }
 
     private fun createResponseCreateRequestParams(): ResponseCreateParams {

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesTextTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesTextTest.kt
@@ -46,7 +46,11 @@ internal class ResponsesTextTest : AbstractOpenaiTest() {
             .first()
             .asOutputText()
             .text() shouldBe "Find. Create. Sell."
-        result.model().asString() shouldBe modelName
+        result
+            .model()
+            .chat()
+            .orElseThrow()
+            .asString() shouldBe modelName
     }
 
     private fun createResponseCreateRequestParams(): ResponseCreateParams {


### PR DESCRIPTION
# Fix tool_choice value in OpenAPI Responses API

Update test to match openapi client changes

This pull request includes several changes to the `ai-mocks-openai` project, focusing on the reorganization of model generation, updates to response models, and enhancements to testing. The most important changes include reordering models in the build configuration, modifying the `Response` data class, adding new data classes for token usage and incomplete details, and updating the test classes to use a new abstract test class.

### Build Configuration Updates:
* Reordered models in `openApiGenerate` to include new models and remove obsolete ones. (`ai-mocks-openai/build.gradle.kts`) [[1]](diffhunk://#diff-7d26c83b57c537ace0ed1aa9fef96778cf3575fbe387dce4bb5d7d8a9ab230dbR47-L61) [[2]](diffhunk://#diff-7d26c83b57c537ace0ed1aa9fef96778cf3575fbe387dce4bb5d7d8a9ab230dbL70)

### Response Model Updates:
* Added `ResponseError` import and modified `Response` data class to include new fields `incompleteDetails`, `usage`, and `error`. (`ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/model/responses/ResponseModels.kt`) [[1]](diffhunk://#diff-1347974f9d65fb9ed73768118392c023e8f0d6dd330641618451faefaf63c11cR25) [[2]](diffhunk://#diff-1347974f9d65fb9ed73768118392c023e8f0d6dd330641618451faefaf63c11cL165-R167) [[3]](diffhunk://#diff-1347974f9d65fb9ed73768118392c023e8f0d6dd330641618451faefaf63c11cR183-R186)
* Introduced new data classes `Usage`, `InputTokensDetails`, `OutputTokensDetails`, and `IncompleteDetails` for detailed response information. (`ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/model/responses/ResponseModels.kt`)

### Testing Enhancements:
* Created `AbstractOpenaiResponsesTest` to centralize common response verification logic and updated existing test classes to extend this new abstract class. (`ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/AbstractOpenaiResponsesTest.kt`, `ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesFileInputTest.kt`, `ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesImageInputTest.kt`, `ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesTextTest.kt`) [[1]](diffhunk://#diff-5a3596eb20dc3fb602702085513cf59fd4304c40a1d0a0963db8cf6a8accca9aR1-R35) [[2]](diffhunk://#diff-7528a161f4d5bc44bad95b58bf69b9828dbe0a2b1e1a166e12f1e31699b89079L25-R23) [[3]](diffhunk://#diff-615aef6f0b8ee78b2001f8c95cf902451fcf7ace217b2945b3731b25976eb1f5L30-R28) [[4]](diffhunk://#diff-ac93f21a0185837d38c29d037fc27cab10621b49412174da106979103ad51130L6-R11)

### Miscellaneous Changes:
* Added a new field `startTimestamp` in `AbstractMockOpenaiTest` to record the start time of tests. (`ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/AbstractMockOpenaiTest.kt`) [[1]](diffhunk://#diff-765673584bf10c6394d067360ba7aa1b252e355b0ebf18fe4d92fcf3b47c1df9R18) [[2]](diffhunk://#diff-765673584bf10c6394d067360ba7aa1b252e355b0ebf18fe4d92fcf3b47c1df9R28)
* Updated `OpenaiResponsesBuildingStep` to include token usage details in the response. (`ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesBuildingStep.kt`) [[1]](diffhunk://#diff-21326c08f3a17e0c4883ef2f535c69e31ed1e8c5a93e3cd2ddd02ad24a042f6bL41-R63) [[2]](diffhunk://#diff-21326c08f3a17e0c4883ef2f535c69e31ed1e8c5a93e3cd2ddd02ad24a042f6bR82-R95)