### PR TITLE
A2a docs

### DIFF
--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
@@ -31,6 +31,44 @@ public open class MockAgentServer(
      * > Clients use the Agent Card information to identify the best agent that can perform
      * > a task and leverage A2A to communicate with that remote agent.
      *
+     * Example usage:
+     * ```kotlin
+     * // Configure the mock server to respond with the AgentCard
+     * a2aServer.agentCard() responds {
+     *     delay = 1.milliseconds
+     *     card {
+     *        name = "test-agent"
+     *        description = "test-agent-description"
+     *        url = a2aServer.baseUrl()
+     *        documentationUrl = "https://example.com/documentation"
+     *        version = "0.0.1"
+     *        provider = AgentProvider(
+     *            "Acme, Inc.",
+     *            "https://example.com/organization",
+     *        )
+     *        authentication = AgentAuthentication(
+     *            schemes = listOf("none", "bearer"),
+     *            credentials = "test-token",
+     *        )
+     *        capabilities = AgentCapabilities(
+     *            streaming = true,
+     *            pushNotifications = true,
+     *            stateTransitionHistory = true,
+     *        )
+     *        skills = listOf(
+     *            AgentSkill(
+     *                id = "walk",
+     *                name = "Walk the walk",
+     *            ),
+     *            AgentSkill(
+     *                id = "talk",
+     *                name = "Talk the talk",
+     *            ),
+     *        )
+     *     }
+     * }
+     * ```
+     *
      * @param name An optional identifier for the configured request.
      * @return An instance of `AbstractBuildingStep` allowing further configuration of the response
      *         for agent card requests using `AgentCardResponseSpecification`.
@@ -61,6 +99,32 @@ public open class MockAgentServer(
      * It allows defining how the server should respond to a "send task" JsonRPC request by chaining
      * a response configuration using the `responds` method of the returned `SendTaskBuildingStep`.
      *
+     * Example usage:
+     * ```kotlin
+     * // Create a Task object
+     * val task = Task(
+     *     id = "tid_12345",
+     *     sessionId = null,
+     *     status = TaskStatus(state = "completed"),
+     *     artifacts = listOf(
+     *         Artifact(
+     *             name = "joke",
+     *             parts = listOf(
+     *                 TextPart(
+     *                     text = "This is a joke",
+     *                 ),
+     *             ),
+     *         ),
+     *     ),
+     * )
+     *
+     * // Configure the mock server to respond with the task
+     * a2aServer.sendTask() responds {
+     *     id = 1
+     *     result = task
+     * }
+     * ```
+     *
      * @return An instance of `SendTaskBuildingStep` to define the response behavior for "send task" requests.
      */
     public fun sendTask(): SendTaskBuildingStep = SendTaskBuildingStep(mokksy)
@@ -73,6 +137,29 @@ public open class MockAgentServer(
      * ["Get a Task"](https://google.github.io/A2A/#/documentation?id=get-a-task) endpoint. It creates
      * a request specification that listens for the "tasks/get" JsonRPC method and includes specific configurations
      * for response behaviors that can be chained using the returned `GetTaskBuildingStep` instance.
+     *
+     * Example usage:
+     * ```kotlin
+     * // Configure the mock server to respond with a task
+     * a2aServer.getTask() responds {
+     *     id = 1
+     *     result {
+     *         id = "tid_12345"
+     *         sessionId = null
+     *         status = TaskStatus(state = "completed")
+     *         artifacts = listOf(
+     *             Artifact(
+     *                 name = "joke",
+     *                 parts = listOf(
+     *                     TextPart(
+     *                         text = "This is a joke",
+     *                     ),
+     *                 ),
+     *             ),
+     *         )
+     *     }
+     * }
+     * ```
      *
      * @param name An optional identifier for the configured request. This can be used to distinguish between
      *             multiple mocked behaviors for "Get a Task" requests.

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/AbstractTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/AbstractTest.kt
@@ -7,7 +7,7 @@ internal abstract class AbstractTest {
     protected val logger = KotlinLogging.logger(name = javaClass.canonicalName!!)
     protected val a2aServer = MockAgentServer(verbose = true)
 
-    protected val a2aClient = createA2AClient(a2aServer.port())
+    protected val a2aClient = createA2AClient(url = a2aServer.baseUrl())
 
     @AfterEach
     fun afterEach() {

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/AgentCardTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/AgentCardTest.kt
@@ -57,8 +57,6 @@ internal class AgentCardTest : AbstractTest() {
             a2aServer.agentCard() responds {
                 delay = 1.milliseconds
                 card = agentCard
-                card {
-                }
             }
 
             val response =

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/Clients.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/Clients.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.json.Json
  * @return A configured instance of `HttpClient` with JSON serialization, SSE support,
  *         and a default request base URL pointing to the specified port.
  */
-internal fun createA2AClient(port: Int): HttpClient =
+internal fun createA2AClient(url: String): HttpClient =
     HttpClient(Java) {
         install(ContentNegotiation) {
             Json {
@@ -28,29 +28,6 @@ internal fun createA2AClient(port: Int): HttpClient =
             showCommentEvents()
         }
         install(DefaultRequest) {
-            url("http://127.0.0.1:$port") // Set the base URL
-        }
-    }
-
-/**
- * Creates and configures a Ktor HTTP client using the specified port to set the base URL.
- * The client leverages the `Java` engine and installs plugins such as `ContentNegotiation` for JSON handling
- * and `DefaultRequest` for setting default request parameters.
- *
- * @param port The server port number used to set the base URL for the client.
- * @return A configured instance of [HttpClient].
- */
-internal fun createKtorClient(port: Int): HttpClient =
-    HttpClient(Java) {
-        install(ContentNegotiation) {
-            Json {
-                // Configure JSON serialization
-                prettyPrint = true
-                isLenient = true
-                ignoreUnknownKeys = true
-            }
-        }
-        install(DefaultRequest) {
-            url("http://127.0.0.1:$port") // Set the base URL
+            url(url) // Set the base URL
         }
     }

--- a/docs/content/docs/ai-mocks/a2s.md
+++ b/docs/content/docs/ai-mocks/a2s.md
@@ -1,0 +1,174 @@
+---
+title: "Agent2Agent Protocol"
+#weight: 50
+toc: true
+---
+
+[MockAgentServer](https://github.com/kpavlov/ai-mocks/blob/main/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt) provides a local mock server for simulating [A2A (Agent-to-Agent) API endpoints](https://google.github.io/A2A/). It simplifies testing by allowing you to define request expectations and responses without making real network calls.
+
+## Quick Start
+
+1. **Add Dependency**
+   Include the library in your test dependencies (Maven or Gradle).
+
+    {{< tabs "dependencies" >}}
+    {{< tab "Gradle" >}}
+```kotlin
+implementation("me.kpavlov.aimocks:ai-mocks-a2a-jvm:$latestVersion")
+```
+    {{< /tab >}}
+    {{< tab "Maven" >}}
+```xml
+<dependency>
+    <groupId>me.kpavlov.aimocks</groupId>
+    <artifactId>ai-mocks-a2a-jvm</artifactId>
+    <version>[LATEST_VERSION]</version>
+</dependency>
+```
+    {{< /tab >}}
+    {{< /tabs >}}
+
+
+2. **Initialize the Server**
+   ```kotlin
+   val a2aServer = MockAgentServer(verbose = true)
+   ```
+  - The server will start on a random free port by default.
+  - You can retrieve the server's base URL via `a2aServer.baseUrl()`.
+
+3. **Configure Requests and Responses**
+
+## Agent Card Endpoint
+
+The Agent Card endpoint provides information about the agent's capabilities, skills, and authentication mechanisms.
+
+```kotlin
+// Configure the mock server to respond with the AgentCard
+a2aServer.agentCard() responds {
+    delay = 1.milliseconds
+    card {
+      name = "test-agent"
+      description = "test-agent-description"
+      url = a2aServer.baseUrl()
+      documentationUrl = "https://example.com/documentation"
+      version = "0.0.1"
+      provider = AgentProvider(
+        "Acme, Inc.",
+        "https://example.com/organization",
+      )
+      authentication = AgentAuthentication(
+        schemes = listOf("none", "bearer"),
+        credentials = "test-token",
+      )
+      capabilities = AgentCapabilities(
+        streaming = true,
+        pushNotifications = true,
+        stateTransitionHistory = true,
+      )
+      skills = listOf(
+        AgentSkill(
+          id = "walk",
+          name = "Walk the walk",
+        ),
+        AgentSkill(
+          id = "talk",
+          name = "Talk the talk",
+        ),
+      )
+    }
+}
+```
+
+## Get Task Endpoint
+
+The Get Task endpoint allows clients to retrieve information about a specific task.
+
+```kotlin
+// Configure the mock server to respond with a task
+a2aServer.getTask() responds {
+    id = 1
+    result {
+        id = "tid_12345"
+        sessionId = null
+        status = TaskStatus(state = "completed")
+        artifacts = listOf(
+            Artifact(
+                name = "joke",
+                parts = listOf(
+                    TextPart(
+                        text = "This is a joke",
+                    ),
+                ),
+            ),
+        )
+    }
+}
+```
+
+## Send Task Endpoint
+
+The Send Task endpoint allows clients to send a task to the agent for processing.
+
+```kotlin
+// Create a Task object
+val task = Task(
+    id = "tid_12345",
+    sessionId = null,
+    status = TaskStatus(state = "completed"),
+    artifacts = listOf(
+        Artifact(
+            name = "joke",
+            parts = listOf(
+                TextPart(
+                    text = "This is a joke",
+                ),
+            ),
+        ),
+    ),
+)
+
+// Configure the mock server to respond with the task
+a2aServer.sendTask() responds {
+    id = 1
+    result = task
+}
+```
+
+## Making Requests to the Mock Server
+
+You can use any HTTP client to make requests to the mock server. Here's an example using Ktor:
+
+```kotlin
+// Create a Ktor client
+val a2aClient = HttpClient(Java) {
+    install(ContentNegotiation) {
+        Json {
+            prettyPrint = true
+            isLenient = true
+            ignoreUnknownKeys = true
+        }
+    }
+    install(SSE) {
+        showRetryEvents()
+        showCommentEvents()
+    }
+    install(DefaultRequest) {
+        url(a2aServer.baseUrl()) // Set the base URL
+    }
+}
+
+// Make a request to the Agent Card endpoint
+val receivedCard = a2aClient
+    .get("/.well-known/agent.json")
+    .body<AgentCard>()
+```
+
+## Verifying Requests
+
+After your test is complete, you can verify that all expected requests were received:
+
+```kotlin
+a2aServer.verifyNoUnmatchedRequests()
+```
+
+This ensures that your test made all the expected requests to the mock server.


### PR DESCRIPTION
This pull request introduces improvements to the `MockAgentServer` class and associated tests, along with comprehensive documentation for the `Agent2Agent` protocol. The most important changes include adding example usage to the `MockAgentServer` methods, updating the client creation to use URLs instead of ports, and enhancing the documentation.

### Enhancements to `MockAgentServer`:

* Added detailed example usage for configuring the mock server to respond with `AgentCard`, `Task`, and `GetTask` in the `MockAgentServer` class. (`ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt`) [[1]](diffhunk://#diff-9a47aa1803b8196d232cbff872837068e84d94573b208e8af0b3b0b9eaec6dd3R34-R71) [[2]](diffhunk://#diff-9a47aa1803b8196d232cbff872837068e84d94573b208e8af0b3b0b9eaec6dd3R102-R127) [[3]](diffhunk://#diff-9a47aa1803b8196d232cbff872837068e84d94573b208e8af0b3b0b9eaec6dd3R141-R163)

### Updates to Client Creation:

* Updated `createA2AClient` function to use URL instead of port for setting the base URL. (`ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/Clients.kt`) [[1]](diffhunk://#diff-9e835551baee909b53b9d10f5863e0b12ac8f569c7efeb3c470b10e17fd14893L17-R17) [[2]](diffhunk://#diff-9e835551baee909b53b9d10f5863e0b12ac8f569c7efeb3c470b10e17fd14893L31-R31)
* Modified `AbstractTest` and `AgentCardTest` to reflect changes in client creation. (`ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/AbstractTest.kt`, `ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/AgentCardTest.kt`) [[1]](diffhunk://#diff-e8e7be798c3deab21a2b5c688cb577994cd420eb726b8500f22b7ccfd6d1cebbL10-R10) [[2]](diffhunk://#diff-06ceb064fecd61fb2fd38c208f59affb0a0a4731e3320efa997f039cb44f6665L60-L61)

### Documentation:

* Added comprehensive documentation for the `Agent2Agent` protocol, including quick start, endpoint configuration, and request verification sections. (`docs/content/docs/ai-mocks/a2s.md`)