### PR TITLE
Simplify path configuration for mock handlers.

### DIFF
--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
@@ -170,8 +170,8 @@ public open class MockAgentServer(
         val requestStep =
             mokksy
                 .post(name = name, requestType = GetTaskRequest::class) {
-                    this.path("/")
-                    this.bodyMatchesPredicate {
+                    path("/")
+                    bodyMatchesPredicate {
                         it?.method == "tasks/get"
                     }
                 }

--- a/ai-mocks-anthropic/src/commonMain/kotlin/me/kpavlov/aimocks/anthropic/MockAnthropic.kt
+++ b/ai-mocks-anthropic/src/commonMain/kotlin/me/kpavlov/aimocks/anthropic/MockAnthropic.kt
@@ -1,7 +1,6 @@
 package me.kpavlov.aimocks.anthropic
 
 import com.anthropic.models.messages.MessageCreateParams
-import io.kotest.matchers.equals.beEqual
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig
 import me.kpavlov.aimocks.core.AbstractMockLlm
 import me.kpavlov.mokksy.ServerConfiguration
@@ -44,7 +43,7 @@ public open class MockAnthropic(
                 val chatRequestSpec = AnthropicMessagesRequestSpecification()
                 block(chatRequestSpec)
 
-                path = beEqual("/v1/messages")
+                path("/v1/messages")
 
                 body += chatRequestSpec.requestBody
 

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/MockOpenai.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/MockOpenai.kt
@@ -1,7 +1,6 @@
 package me.kpavlov.aimocks.openai
 
 import io.kotest.assertions.json.containJsonKeyValue
-import io.kotest.matchers.equals.beEqual
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import me.kpavlov.aimocks.core.AbstractMockLlm
@@ -60,7 +59,7 @@ public open class MockOpenai(
                 val chatRequestSpec = OpenaiChatCompletionRequestSpecification()
                 block(chatRequestSpec)
 
-                path = beEqual("/v1/chat/completions")
+                path("/v1/chat/completions")
 
                 body += chatRequestSpec.requestBody
 
@@ -103,7 +102,7 @@ public open class MockOpenai(
                 val chatRequestSpec = OpenaiResponsesRequestSpecification()
                 block(chatRequestSpec)
 
-                path = beEqual("/v1/responses")
+                path("/v1/responses")
 
                 body += chatRequestSpec.requestBody
 

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/ResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/ResponseDefinition.kt
@@ -6,6 +6,7 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.log
 import io.ktor.server.response.ResponseHeaders
 import io.ktor.server.response.respond
+import io.ktor.util.cio.ChannelWriteException
 import kotlinx.coroutines.delay
 import kotlin.time.Duration
 
@@ -47,9 +48,14 @@ public open class ResponseDefinition<P, T>(
         if (verbose) {
             call.application.log.debug("Sending {}: {}", httpStatus, body)
         }
-        call.respond(
-            status = httpStatus,
-            message = body ?: "" as Any,
-        )
+        try {
+            call.respond(
+                status = httpStatus,
+                message = body ?: "" as Any,
+            )
+        } catch (e: ChannelWriteException) {
+            // We can't do anything about it
+            call.application.log.debug(e.message, e)
+        }
     }
 }


### PR DESCRIPTION
refactor: Simplify path configuration for mock handlers.

Replaces `path = beEqual(...)` with a direct `path(...)` method across OpenAI, Anthropic, and A2A mocks. This streamlines the API usage, improves readability, and ensures consistency in the codebase. Removed unused imports for cleanup.