### PR TITLE
a2a: SendTaskStreaming, CancelTask, documantation

### DIFF
--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/CancelTaskRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/CancelTaskRequest.kt
@@ -17,6 +17,9 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 
+private const val cg_str0 = "2.0"
+private const val cg_str1 = "tasks/cancel"
+
 @Serializable
 public data class CancelTaskRequest(
     @SerialName("jsonrpc")
@@ -35,10 +38,5 @@ public data class CancelTaskRequest(
     init {
         require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
         require(method == cg_str1) { "method not constant value $cg_str1 - $method" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "2.0"
-        private const val cg_str1 = "tasks/cancel"
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/CancelTaskResponse.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/CancelTaskResponse.kt
@@ -30,10 +30,6 @@ public data class CancelTaskResponse(
     val error: JSONRPCError? = null,
 ) {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "2.0"
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0- $jsonrpc" }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskResponse.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskResponse.kt
@@ -16,8 +16,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 
-private const val cg_str0 = "2.0"
-
 @Serializable
 public data class SendTaskResponse(
     @SerialName("jsonrpc")
@@ -25,13 +23,13 @@ public data class SendTaskResponse(
     val jsonrpc: String = "2.0",
     @SerialName("id")
     @Serializable(with = RequestIdSerializer::class)
-    var id: RequestId? = null,
+    val id: RequestId? = null,
     @SerialName("result")
-    var result: Task? = null, // todo: val
+    val result: Task? = null, // todo: val
     @SerialName("error")
     val error: JSONRPCError? = null,
 ) {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskStreamingRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskStreamingRequest.kt
@@ -17,6 +17,9 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 
+private const val cg_str0 = "2.0"
+private const val cg_str1 = "tasks/sendSubscribe"
+
 @Serializable
 public data class SendTaskStreamingRequest(
     @SerialName("jsonrpc")
@@ -35,10 +38,5 @@ public data class SendTaskStreamingRequest(
     init {
         require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
         require(method == cg_str1) { "method not constant value $cg_str1 - $method" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "2.0"
-        private const val cg_str1 = "tasks/sendSubscribe"
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskStreamingResponse.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskStreamingResponse.kt
@@ -12,31 +12,30 @@
 package me.kpavlov.aimocks.a2a.model
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.Polymorphic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
+import me.kpavlov.aimocks.a2a.model.serializers.TaskUpdateEventSerializer
 
 @Serializable
 public data class SendTaskStreamingResponse(
-    @Contextual
     @SerialName("jsonrpc")
+    @EncodeDefault
     val jsonrpc: String = "2.0",
-    @Contextual
     @SerialName("id")
     @Serializable(with = RequestIdSerializer::class)
     var id: RequestId? = null,
-    @Contextual
     @SerialName("result")
-    val result: Any? = null,
+    @Polymorphic
+    @Serializable(with = TaskUpdateEventSerializer::class)
+    val result: TaskUpdateEvent? = null,
     @Contextual
     @SerialName("error")
     val error: JSONRPCError? = null,
 ) {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "2.0"
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/Task.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/Task.kt
@@ -18,9 +18,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class Task(
     @SerialName("id")
-    val id: String,
+    val id: TaskId,
     @SerialName("sessionId")
-    val sessionId: String? = null,
+    val sessionId: SessionId? = null,
     @SerialName("status")
     val status: TaskStatus,
     @SerialName("artifacts")

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskArtifactUpdateEvent.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskArtifactUpdateEvent.kt
@@ -11,19 +11,17 @@
  */
 package me.kpavlov.aimocks.a2a.model
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class TaskArtifactUpdateEvent(
-    @Contextual
     @SerialName("id")
-    val id: String,
-    @Contextual
+    val id: TaskId,
     @SerialName("artifact")
     val artifact: Artifact,
-    @Contextual
     @SerialName("metadata")
     val metadata: Metadata? = null,
-)
+) : TaskUpdateEvent {
+    override fun id(): TaskId = id
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskStatusUpdateEvent.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskStatusUpdateEvent.kt
@@ -26,4 +26,6 @@ public data class TaskStatusUpdateEvent(
     val final: Boolean = false,
     @SerialName("metadata")
     val metadata: Metadata? = null,
-)
+) : TaskUpdateEvent {
+    override fun id(): TaskId = id
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskUpdateEvent.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskUpdateEvent.kt
@@ -1,0 +1,10 @@
+package me.kpavlov.aimocks.a2a.model
+
+import kotlinx.serialization.Serializable
+import me.kpavlov.aimocks.a2a.model.serializers.TaskUpdateEventSerializer
+
+@Serializable
+(with = TaskUpdateEventSerializer::class)
+public sealed interface TaskUpdateEvent {
+    public fun id(): TaskId
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/serializers/TaskUpdateEventSerializer.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/serializers/TaskUpdateEventSerializer.kt
@@ -1,0 +1,101 @@
+package me.kpavlov.aimocks.a2a.model.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import me.kpavlov.aimocks.a2a.model.TaskArtifactUpdateEvent
+import me.kpavlov.aimocks.a2a.model.TaskStatusUpdateEvent
+import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
+
+/**
+ * Polymorphic serializer for TaskUpdateEvent hierarchy.
+ * Determines which subclass to use based on the presence of "artifact" or "status" properties.
+ */
+public class TaskUpdateEventSerializer : KSerializer<TaskUpdateEvent> {
+    // Serializers for the concrete implementations
+    private val statusUpdateSerializer = TaskStatusUpdateEvent.serializer()
+    private val artifactUpdateSerializer = TaskArtifactUpdateEvent.serializer()
+
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("TaskUpdateEvent")
+
+    override fun deserialize(decoder: Decoder): TaskUpdateEvent {
+        // We need to work with JSON to inspect the properties
+        val jsonDecoder =
+            decoder as? JsonDecoder
+                ?: throw SerializationException(
+                    "TaskUpdateEventSerializer can only be used with JSON",
+                )
+
+        val jsonElement = jsonDecoder.decodeJsonElement()
+        if (jsonElement !is JsonObject) {
+            throw SerializationException("Expected JSON object for TaskUpdateEvent")
+        }
+
+        return if (jsonElement["result"] is JsonElement) {
+            doDecode(jsonElement["result"]!!, jsonDecoder)
+        } else {
+            doDecode(jsonElement, jsonDecoder)
+        }
+    }
+
+    private fun doDecode(
+        jsonElement: JsonElement,
+        jsonDecoder: JsonDecoder,
+    ): TaskUpdateEvent {
+        // Determine which subclass to use based on the presence of properties
+        return when {
+            "artifact" in jsonElement.jsonObject -> {
+                // If it has an "artifact" property, it's a TaskArtifactUpdateEvent
+                jsonDecoder.json.decodeFromJsonElement(artifactUpdateSerializer, jsonElement)
+            }
+
+            "status" in jsonElement.jsonObject -> {
+                // If it has a "status" property, it's a TaskStatusUpdateEvent
+                jsonDecoder.json.decodeFromJsonElement(statusUpdateSerializer, jsonElement)
+            }
+
+            else -> {
+                throw SerializationException(
+                    "Cannot determine TaskUpdateEvent type: neither 'artifact' nor 'status' property found",
+                )
+            }
+        }
+    }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: TaskUpdateEvent,
+    ) {
+        val jsonEncoder =
+            encoder as? JsonEncoder
+                ?: throw SerializationException(
+                    "TaskUpdateEventSerializer can only be used with JSON",
+                )
+
+        // Delegate to the appropriate serializer based on the concrete type
+        val jsonElement: JsonElement =
+            when (value) {
+                is TaskStatusUpdateEvent ->
+                    jsonEncoder.json.encodeToJsonElement(
+                        statusUpdateSerializer,
+                        value,
+                    )
+
+                is TaskArtifactUpdateEvent ->
+                    jsonEncoder.json.encodeToJsonElement(
+                        artifactUpdateSerializer,
+                        value,
+                    )
+            }
+
+        jsonEncoder.encodeJsonElement(jsonElement)
+    }
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/CancelTaskBuildingStep.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/CancelTaskBuildingStep.kt
@@ -1,0 +1,27 @@
+package me.kpavlov.aimocks.a2a
+
+import me.kpavlov.aimocks.a2a.model.CancelTaskRequest
+import me.kpavlov.aimocks.a2a.model.CancelTaskResponse
+import me.kpavlov.aimocks.core.AbstractBuildingStep
+import me.kpavlov.mokksy.BuildingStep
+import me.kpavlov.mokksy.MokksyServer
+
+public class CancelTaskBuildingStep(
+    mokksy: MokksyServer,
+    buildingStep: BuildingStep<CancelTaskRequest>,
+) : AbstractBuildingStep<CancelTaskRequest, CancelTaskResponseSpecification>(
+        mokksy,
+        buildingStep,
+    ) {
+    override infix fun responds(block: CancelTaskResponseSpecification.() -> Unit) {
+        buildingStep.respondsWith<CancelTaskResponse> {
+            val requestBody = request.body
+            val responseDefinition = this.build()
+            val responseSpecification = CancelTaskResponseSpecification(responseDefinition)
+            block.invoke(responseSpecification)
+            val task = requireNotNull(responseSpecification.result) { "Task must be defined" }
+            body =
+                CancelTaskResponse(id = responseSpecification.id ?: requestBody.id, result = task)
+        }
+    }
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/CancelTaskResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/CancelTaskResponseSpecification.kt
@@ -1,0 +1,26 @@
+package me.kpavlov.aimocks.a2a
+
+import me.kpavlov.aimocks.a2a.model.CancelTaskRequest
+import me.kpavlov.aimocks.a2a.model.CancelTaskResponse
+import me.kpavlov.aimocks.a2a.model.RequestId
+import me.kpavlov.aimocks.a2a.model.Task
+import me.kpavlov.aimocks.a2a.model.TaskBuilder
+import me.kpavlov.aimocks.core.ResponseSpecification
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
+import kotlin.time.Duration
+
+public class CancelTaskResponseSpecification(
+    response: AbstractResponseDefinition<CancelTaskResponse>,
+    public var id: RequestId? = null,
+    public var result: Task? = null,
+    public var delay: Duration = Duration.ZERO,
+) : ResponseSpecification<CancelTaskRequest, CancelTaskResponse>(response = response) {
+    public fun task(block: TaskBuilder.() -> Unit) {
+        require(result == null) { "Task is already defined" }
+        result = TaskBuilder().apply(block).build()
+    }
+
+    public fun result(block: TaskBuilder.() -> Unit) {
+        task { block.invoke(this) }
+    }
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetTaskRequestSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetTaskRequestSpecification.kt
@@ -1,3 +1,0 @@
-package me.kpavlov.aimocks.a2a
-
-public open class GetTaskRequestSpecification

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
@@ -2,7 +2,10 @@ package me.kpavlov.aimocks.a2a
 
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import me.kpavlov.aimocks.a2a.model.CancelTaskRequest
 import me.kpavlov.aimocks.a2a.model.GetTaskRequest
+import me.kpavlov.aimocks.a2a.model.SendTaskRequest
+import me.kpavlov.aimocks.a2a.model.SendTaskStreamingRequest
 import me.kpavlov.aimocks.core.AbstractBuildingStep
 import me.kpavlov.aimocks.core.AbstractMockLlm
 import me.kpavlov.mokksy.ServerConfiguration
@@ -127,7 +130,56 @@ public open class MockAgentServer(
      *
      * @return An instance of `SendTaskBuildingStep` to define the response behavior for "send task" requests.
      */
-    public fun sendTask(): SendTaskBuildingStep = SendTaskBuildingStep(mokksy)
+    @JvmOverloads
+    public fun sendTask(name: String? = null): SendTaskBuildingStep {
+        val requestStep =
+            mokksy
+                .post(name = name, requestType = SendTaskRequest::class) {
+                    path("/")
+                    bodyMatchesPredicate {
+                        it?.method == "tasks/send"
+                    }
+                }
+
+        return SendTaskBuildingStep(
+            buildingStep = requestStep,
+            mokksy = mokksy,
+        )
+    }
+
+    @JvmOverloads
+    public fun cancelTask(name: String? = null): CancelTaskBuildingStep {
+        val requestStep =
+            mokksy
+                .post(name = name, requestType = CancelTaskRequest::class) {
+                    path("/")
+                    bodyMatchesPredicate {
+                        it?.method == "tasks/cancel"
+                    }
+                }
+
+        return CancelTaskBuildingStep(
+            buildingStep = requestStep,
+            mokksy = mokksy,
+        )
+    }
+
+    @JvmOverloads
+    public fun sendTaskStreaming(name: String? = null): SendTaskStreamingBuildingStep {
+        val requestStep =
+            mokksy
+                .post(name = name, requestType = SendTaskStreamingRequest::class) {
+                    path("/")
+                    bodyMatchesPredicate {
+                        it?.method == "tasks/sendSubscribe"
+                    }
+                }
+
+        return SendTaskStreamingBuildingStep(
+            buildingStep = requestStep,
+            mokksy = mokksy,
+        )
+    }
 
     /**
      * Configures the behavior of the mocking server to handle
@@ -166,6 +218,7 @@ public open class MockAgentServer(
      * @return An instance of `GetTaskBuildingStep` that allows for further configuration of the mock
      *         response behavior for "Get a Task" requests.
      */
+    @JvmOverloads
     public fun getTask(name: String? = null): GetTaskBuildingStep {
         val requestStep =
             mokksy

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SendTaskResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SendTaskResponseSpecification.kt
@@ -1,0 +1,26 @@
+package me.kpavlov.aimocks.a2a
+
+import me.kpavlov.aimocks.a2a.model.RequestId
+import me.kpavlov.aimocks.a2a.model.SendTaskRequest
+import me.kpavlov.aimocks.a2a.model.SendTaskResponse
+import me.kpavlov.aimocks.a2a.model.Task
+import me.kpavlov.aimocks.a2a.model.TaskBuilder
+import me.kpavlov.aimocks.core.ResponseSpecification
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
+import kotlin.time.Duration
+
+public class SendTaskResponseSpecification(
+    response: AbstractResponseDefinition<SendTaskResponse>,
+    public var id: RequestId? = null,
+    public var result: Task? = null,
+    public var delay: Duration = Duration.ZERO,
+) : ResponseSpecification<SendTaskRequest, SendTaskResponse>(response = response) {
+    public fun task(block: TaskBuilder.() -> Unit) {
+        require(result == null) { "Task is already defined" }
+        result = TaskBuilder().apply(block).build()
+    }
+
+    public fun result(block: TaskBuilder.() -> Unit) {
+        task { block.invoke(this) }
+    }
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SendTaskStreamingBuildingStep.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SendTaskStreamingBuildingStep.kt
@@ -1,0 +1,36 @@
+package me.kpavlov.aimocks.a2a
+
+import io.ktor.sse.ServerSentEvent
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
+import me.kpavlov.aimocks.a2a.model.SendTaskStreamingRequest
+import me.kpavlov.aimocks.a2a.model.SendTaskStreamingResponse
+import me.kpavlov.aimocks.core.AbstractBuildingStep
+import me.kpavlov.mokksy.BuildingStep
+import me.kpavlov.mokksy.MokksyServer
+
+public class SendTaskStreamingBuildingStep(
+    mokksy: MokksyServer,
+    buildingStep: BuildingStep<SendTaskStreamingRequest>,
+) : AbstractBuildingStep<SendTaskStreamingRequest, SendTaskStreamingResponseSpecification>(
+        mokksy,
+        buildingStep,
+    ) {
+    override infix fun responds(block: SendTaskStreamingResponseSpecification.() -> Unit) {
+        buildingStep.respondsWithStream<String> {
+            val requestBody = request.body
+            val responseDefinition = this.build()
+            val responseSpecification = SendTaskStreamingResponseSpecification(responseDefinition)
+            block.invoke(responseSpecification)
+            flow =
+                responseSpecification.responseFlow
+                    ?.map {
+                        SendTaskStreamingResponse(
+                            id = requestBody.id,
+                            result = it,
+                        )
+                    }?.map { Json.encodeToString(it) }
+                    ?.map { ServerSentEvent(data = it).toString() + '\n' }
+        }
+    }
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SendTaskStreamingResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SendTaskStreamingResponseSpecification.kt
@@ -1,0 +1,15 @@
+package me.kpavlov.aimocks.a2a
+
+import kotlinx.coroutines.flow.Flow
+import me.kpavlov.aimocks.a2a.model.SendTaskStreamingRequest
+import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
+import me.kpavlov.aimocks.core.ResponseSpecification
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
+import kotlin.time.Duration
+
+public class SendTaskStreamingResponseSpecification(
+    response: AbstractResponseDefinition<String>,
+    public var responseFlow: Flow<TaskUpdateEvent>? = null,
+    public var delayBetweenChunks: Duration = Duration.ZERO,
+    public var delay: Duration = Duration.ZERO,
+) : ResponseSpecification<SendTaskStreamingRequest, String>(response = response)

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/CancelTaskTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/CancelTaskTest.kt
@@ -1,0 +1,68 @@
+package me.kpavlov.aimocks.a2a
+
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.equals.shouldBeEqual
+import io.ktor.client.call.body
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import me.kpavlov.aimocks.a2a.model.CancelTaskRequest
+import me.kpavlov.aimocks.a2a.model.CancelTaskResponse
+import me.kpavlov.aimocks.a2a.model.Task
+import me.kpavlov.aimocks.a2a.model.TaskIdParams
+import me.kpavlov.aimocks.a2a.model.TaskStatus
+import java.util.UUID
+import kotlin.test.Test
+
+internal class CancelTaskTest : AbstractTest() {
+    /**
+     * https://github.com/google/A2A/blob/gh-pages/documentation.md#send-a-task
+     */
+    @Test
+    fun `Should cancel task`() =
+        runTest {
+            lateinit var expectedTask: Task
+
+            a2aServer.cancelTask() responds {
+                id = 1
+                result {
+                    id = "tid_12345"
+                    sessionId = UUID.randomUUID().toString()
+                    status = TaskStatus(state = "canceled")
+                }
+                expectedTask = requireNotNull(result) { "Result should not be null" }
+            }
+
+            val response =
+                a2aClient
+                    .post("/") {
+                        val jsonRpcRequest =
+                            CancelTaskRequest(
+                                id = "1",
+                                params =
+                                    TaskIdParams(
+                                        id = UUID.randomUUID().toString(),
+                                    ),
+                            )
+                        contentType(ContentType.Application.Json)
+                        setBody(Json.encodeToString(jsonRpcRequest))
+                    }.call
+                    .response
+
+            response.status.shouldBeEqual(HttpStatusCode.OK)
+            val body = response.body<String>()
+            logger.info { "body = $body" }
+            val payload = Json.decodeFromString<CancelTaskResponse>(body)
+
+            val expectedReply =
+                CancelTaskResponse(
+                    id = 1,
+                    result = expectedTask,
+                )
+            payload shouldBeEqualToComparingFields expectedReply
+        }
+}

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/Clients.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/Clients.kt
@@ -20,7 +20,6 @@ internal fun createA2AClient(url: String): HttpClient =
             Json {
                 prettyPrint = true
                 isLenient = true
-                ignoreUnknownKeys = true
             }
         }
         install(SSE) {

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/SendTaskStreamingTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/SendTaskStreamingTest.kt
@@ -1,0 +1,202 @@
+package me.kpavlov.aimocks.a2a
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.ktor.client.plugins.sse.sse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import io.ktor.http.content.TextContent
+import io.ktor.utils.io.InternalAPI
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock.System
+import kotlinx.serialization.json.Json
+import me.kpavlov.aimocks.a2a.model.Artifact
+import me.kpavlov.aimocks.a2a.model.Message
+import me.kpavlov.aimocks.a2a.model.SendTaskStreamingRequest
+import me.kpavlov.aimocks.a2a.model.TaskArtifactUpdateEvent
+import me.kpavlov.aimocks.a2a.model.TaskId
+import me.kpavlov.aimocks.a2a.model.TaskSendParams
+import me.kpavlov.aimocks.a2a.model.TaskStatus
+import me.kpavlov.aimocks.a2a.model.TaskStatusUpdateEvent
+import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
+import me.kpavlov.aimocks.a2a.model.TextPart
+import java.util.UUID
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+
+internal class SendTaskStreamingTest : AbstractTest() {
+    /**
+     * https://github.com/google/A2A/blob/gh-pages/documentation.md#send-a-task
+     */
+    @OptIn(InternalAPI::class)
+    @Test
+    fun `Should send task streaming`() =
+        runTest {
+            val taskId: TaskId = "task_12345"
+
+            a2aServer.sendTaskStreaming() responds {
+                delayBetweenChunks = 1.seconds
+                responseFlow =
+                    flow {
+                        emit(
+                            TaskStatusUpdateEvent(
+                                id = taskId,
+                                status = TaskStatus(state = "working", timestamp = System.now()),
+                            ),
+                        )
+                        emit(
+                            TaskArtifactUpdateEvent(
+                                id = taskId,
+                                artifact =
+                                    Artifact(
+                                        name = "joke",
+                                        parts =
+                                            listOf(
+                                                TextPart(
+                                                    text = "This",
+                                                ),
+                                            ),
+                                        append = false,
+                                    ),
+                            ),
+                        )
+                        emit(
+                            TaskArtifactUpdateEvent(
+                                id = taskId,
+                                artifact =
+                                    Artifact(
+                                        name = "joke",
+                                        parts =
+                                            listOf(
+                                                TextPart(
+                                                    text = "is",
+                                                ),
+                                            ),
+                                        append = false,
+                                    ),
+                            ),
+                        )
+                        emit(
+                            TaskArtifactUpdateEvent(
+                                id = taskId,
+                                artifact =
+                                    Artifact(
+                                        name = "joke",
+                                        parts =
+                                            listOf(
+                                                TextPart(
+                                                    text = "a",
+                                                ),
+                                            ),
+                                        append = false,
+                                    ),
+                            ),
+                        )
+                        emit(
+                            TaskArtifactUpdateEvent(
+                                id = taskId,
+                                artifact =
+                                    Artifact(
+                                        name = "joke",
+                                        parts =
+                                            listOf(
+                                                TextPart(
+                                                    text = "joke!",
+                                                ),
+                                            ),
+                                        append = false,
+                                        lastChunk = true,
+                                    ),
+                            ),
+                        )
+                        emit(
+                            TaskStatusUpdateEvent(
+                                id = taskId,
+                                status = TaskStatus(state = "completed", timestamp = System.now()),
+                                final = true,
+                            ),
+                        )
+                    }
+            }
+
+            var collectedEvents = ConcurrentLinkedQueue<TaskUpdateEvent>()
+            a2aClient.sse(
+                request = {
+                    url { a2aServer.baseUrl() }
+                    method = HttpMethod.Post
+                    val payload =
+                        SendTaskStreamingRequest(
+                            id = "1",
+                            params =
+                                TaskSendParams(
+                                    id = UUID.randomUUID().toString(),
+                                    message =
+                                        Message(
+                                            role = Message.Role.user,
+                                            parts =
+                                                listOf(
+                                                    TextPart(
+                                                        text = "Tell me a joke",
+                                                    ),
+                                                ),
+                                        ),
+                                ),
+                        )
+                    body =
+                        TextContent(
+                            text = Json.encodeToString(payload),
+                            contentType = ContentType.Application.Json,
+                        )
+                },
+            ) {
+                var reading = true
+                while (reading) {
+                    incoming.collect {
+                        println("Event from server:\n$it")
+                        it.data?.let {
+                            val event = Json.decodeFromString<TaskUpdateEvent>(it)
+                            collectedEvents.add(event)
+                            if (!handleEvent(event)) {
+                                reading = false
+                                cancel("Finished")
+                            }
+                        }
+                    }
+                }
+            }
+
+            collectedEvents shouldHaveSize 6
+            collectedEvents.forEach {
+                it.id() shouldBe taskId
+            }
+            (collectedEvents.first() as TaskStatusUpdateEvent).let {
+                it.status.state shouldBe "working"
+                it.status.timestamp.shouldNotBeNull()
+            }
+            (collectedEvents.last() as TaskStatusUpdateEvent).let {
+                it.final shouldBe true
+                it.status.state shouldBe "completed"
+                it.status.timestamp.shouldNotBeNull()
+            }
+        }
+
+    private fun handleEvent(event: TaskUpdateEvent): Boolean {
+        when (event) {
+            is TaskStatusUpdateEvent -> {
+                logger.info { "Task status: $event" }
+                if (event.final) {
+                    return false
+                }
+            }
+
+            is TaskArtifactUpdateEvent -> {
+                logger.info { "Task artifact: $event" }
+            }
+        }
+        return true
+    }
+}

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/AbstractResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/AbstractResponseDefinition.kt
@@ -26,7 +26,7 @@ public abstract class AbstractResponseDefinition<T>(
     public val httpStatus: HttpStatusCode = HttpStatusCode.OK,
     public val headers: (ResponseHeaders.() -> Unit)? = null,
     public val headerList: List<Pair<String, String>> = emptyList<Pair<String, String>>(),
-    public val delay: Duration = Duration.ZERO,
+    public open val delay: Duration = Duration.ZERO,
 ) {
     internal abstract suspend fun writeResponse(
         call: ApplicationCall,

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/SseStreamResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/SseStreamResponseDefinition.kt
@@ -14,13 +14,13 @@ import kotlin.time.Duration
 
 public open class SseStreamResponseDefinition<P>(
     override val chunkFlow: Flow<ServerSentEvent>? = null,
-    delay: Duration,
+    delay: Duration = Duration.ZERO,
 ) : StreamResponseDefinition<P, ServerSentEvent>(delay = delay) {
     override suspend fun writeResponse(
         call: ApplicationCall,
         verbose: Boolean,
     ) {
-        val theFlow = this.chunkFlow ?: emptyFlow()
+        val theFlow = chunkFlow ?: emptyFlow()
         val sseContent =
             SSEServerContent(call) {
                 theFlow.collect {


### PR DESCRIPTION
- feat(models): implement polymorphic serializer for TaskUpdateEvent 

    Added TaskUpdateEventSerializer to enable polymorphic serialization and deserialization for the TaskUpdateEvent hierarchy. Updated related models to include the new serialization logic and adjusted test cases for better event validation.

    This change facilitates cleaner handling of TaskUpdateEvent subtypes (e.g., TaskStatusUpdateEvent and TaskArtifactUpdateEvent) and improves client-side test coverage.

- refactor(response): replace Writer with ByteWriteChannel

    Updated the response-writing logic to use ByteWriteChannel instead of Writer, improving consistency and allowing more efficient handling of binary data. Switched to `respondBytesWriter` for better integration with Ktor's API. General refactoring enhances extensibility and future-proofing.

- feat(a2a): add SendTaskStreaming support

    Implemented SendTaskStreamingBuildingStep for handling streaming task requests.
    Added relevant test cases and response specification to support streaming use cases.
    Updated MockAgentServer with a method to handle SendTaskStreamingRequest.

- refactor(models): Introduce TaskUpdateEvent

    Replaced `Any` with sealed interface `TaskUpdateEvent` for `result` in `SendTaskStreamingResponse` to improve type safety. Moved constants out of companion objects and reused them across classes. Introduced `TaskUpdateEvent` interface for task-specific update events to ensure consistency and hierarchy.

- feat(a2a): add CancelTask handler and response specification

    Introduced `CancelTaskResponseSpecification` and `CancelTaskBuildingStep` for handling "cancel task" functionality in the A2A module. Added a test case to validate the feature and updated related models to support the new behavior. Minor refactoring includes optimizing constants placement in `CancelTaskRequest` and `CancelTaskResponse`.

- feat(a2a): enhance "send task" request handling

    Added support for configurable "send task" requests with optional name parameter. Refactored "SendTaskBuildingStep" to extend "AbstractBuildingStep" and introduced "SendTaskResponseSpecification" for flexible response customization.

- docs(a2a): document Cancel Task operation
- docs(a2a): document Send Task Streaming operation
- docs(a2a): add example requests