### PR TITLE
A2A: aSupport 'Set Task Push Notification' endpoint

### DIFF
--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SetTaskPushNotificationRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SetTaskPushNotificationRequest.kt
@@ -31,12 +31,9 @@ public data class SetTaskPushNotificationRequest(
     val params: TaskPushNotificationConfig,
 ) : A2ARequest {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
-        require(method == cg_str1) { "method not constant value $cg_str1 - $method" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "2.0"
-        private const val cg_str1 = "tasks/pushNotification/set"
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
+        require(method == "tasks/pushNotification/set") {
+            "method not constant value 'tasks/pushNotification/set' - $method"
+        }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SetTaskPushNotificationResponse.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SetTaskPushNotificationResponse.kt
@@ -32,10 +32,6 @@ public data class SetTaskPushNotificationResponse(
     val error: JSONRPCError? = null,
 ) {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "2.0"
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskPushNotificationConfig.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskPushNotificationConfig.kt
@@ -11,16 +11,13 @@
  */
 package me.kpavlov.aimocks.a2a.model
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class TaskPushNotificationConfig(
-    @Contextual
     @SerialName("id")
-    val id: String,
-    @Contextual
+    val id: TaskId,
     @SerialName("pushNotificationConfig")
     val pushNotificationConfig: PushNotificationConfig,
 )

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
@@ -6,6 +6,7 @@ import me.kpavlov.aimocks.a2a.model.CancelTaskRequest
 import me.kpavlov.aimocks.a2a.model.GetTaskRequest
 import me.kpavlov.aimocks.a2a.model.SendTaskRequest
 import me.kpavlov.aimocks.a2a.model.SendTaskStreamingRequest
+import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationRequest
 import me.kpavlov.aimocks.core.AbstractBuildingStep
 import me.kpavlov.aimocks.core.AbstractMockLlm
 import me.kpavlov.mokksy.ServerConfiguration
@@ -230,6 +231,23 @@ public open class MockAgentServer(
                 }
 
         return GetTaskBuildingStep(
+            buildingStep = requestStep,
+            mokksy = mokksy,
+        )
+    }
+
+    @JvmOverloads
+    public fun setTaskPushNotification(name: String? = null): SetTaskPushNotificationBuildingStep {
+        val requestStep =
+            mokksy
+                .post(name = name, requestType = SetTaskPushNotificationRequest::class) {
+                    path("/")
+                    bodyMatchesPredicate {
+                        it?.method == "tasks/pushNotification/set"
+                    }
+                }
+
+        return SetTaskPushNotificationBuildingStep(
             buildingStep = requestStep,
             mokksy = mokksy,
         )

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SetTaskPushNotificationBuildingStep.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SetTaskPushNotificationBuildingStep.kt
@@ -1,0 +1,34 @@
+package me.kpavlov.aimocks.a2a
+
+import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationRequest
+import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationResponse
+import me.kpavlov.aimocks.core.AbstractBuildingStep
+import me.kpavlov.mokksy.BuildingStep
+import me.kpavlov.mokksy.MokksyServer
+
+public class SetTaskPushNotificationBuildingStep(
+    mokksy: MokksyServer,
+    buildingStep: BuildingStep<SetTaskPushNotificationRequest>,
+) : AbstractBuildingStep<
+        SetTaskPushNotificationRequest,
+        SetTaskPushNotificationResponseSpecification,
+    >(
+        mokksy,
+        buildingStep,
+    ) {
+    override infix fun responds(block: SetTaskPushNotificationResponseSpecification.() -> Unit) {
+        buildingStep.respondsWith<SetTaskPushNotificationResponse> {
+            val requestBody = request.body
+            val responseDefinition = this.build()
+            val responseSpecification =
+                SetTaskPushNotificationResponseSpecification(responseDefinition)
+            block.invoke(responseSpecification)
+            val task = requireNotNull(responseSpecification.result) { "Task must be defined" }
+            body =
+                SetTaskPushNotificationResponse(
+                    id = responseSpecification.id ?: requestBody.id,
+                    result = task,
+                )
+        }
+    }
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SetTaskPushNotificationResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SetTaskPushNotificationResponseSpecification.kt
@@ -1,0 +1,18 @@
+package me.kpavlov.aimocks.a2a
+
+import me.kpavlov.aimocks.a2a.model.RequestId
+import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationRequest
+import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationResponse
+import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfig
+import me.kpavlov.aimocks.core.ResponseSpecification
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
+import kotlin.time.Duration
+
+public class SetTaskPushNotificationResponseSpecification(
+    response: AbstractResponseDefinition<SetTaskPushNotificationResponse>,
+    public var id: RequestId? = null,
+    public var result: TaskPushNotificationConfig? = null,
+    public var delay: Duration = Duration.ZERO,
+) : ResponseSpecification<SetTaskPushNotificationRequest, SetTaskPushNotificationResponse>(
+        response = response,
+    )

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/SetTaskPushNotoficationTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/SetTaskPushNotoficationTest.kt
@@ -1,0 +1,71 @@
+package me.kpavlov.aimocks.a2a
+
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.equals.shouldBeEqual
+import io.ktor.client.call.body
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import me.kpavlov.aimocks.a2a.model.AuthenticationInfo
+import me.kpavlov.aimocks.a2a.model.PushNotificationConfig
+import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationRequest
+import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationResponse
+import me.kpavlov.aimocks.a2a.model.TaskId
+import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfig
+import kotlin.test.Test
+
+internal class SetTaskPushNotoficationTest : AbstractTest() {
+    /**
+     * https://github.com/google/A2A/blob/gh-pages/documentation.md#send-a-task
+     */
+    @Test
+    fun `Should send task`() =
+        runTest {
+            val taskId: TaskId = "task_12345"
+            val config =
+                TaskPushNotificationConfig(
+                    id = taskId,
+                    pushNotificationConfig =
+                        PushNotificationConfig(
+                            url = "https://example.com/callback",
+                            token = "abc.def.jk",
+                            authentication =
+                                AuthenticationInfo(
+                                    schemes = listOf("Bearer"),
+                                ),
+                        ),
+                )
+
+            a2aServer.setTaskPushNotification() responds {
+                id = 1
+                result = config
+            }
+
+            val response =
+                a2aClient
+                    .post("/") {
+                        val jsonRpcRequest =
+                            SetTaskPushNotificationRequest(
+                                id = "1",
+                                params = config,
+                            )
+                        contentType(ContentType.Application.Json)
+                        setBody(Json.encodeToString(jsonRpcRequest))
+                    }.call
+                    .response
+
+            response.status.shouldBeEqual(HttpStatusCode.OK)
+            val body = response.body<String>()
+            logger.info { "body = $body" }
+            val payload = Json.decodeFromString<SetTaskPushNotificationResponse>(body)
+            payload shouldBeEqualToComparingFields
+                SetTaskPushNotificationResponse(
+                    id = 1,
+                    result = config,
+                )
+        }
+}

--- a/docs/content/docs/ai-mocks/a2s.md
+++ b/docs/content/docs/ai-mocks/a2s.md
@@ -238,6 +238,30 @@ a2aServer.cancelTask() responds {
 }
 ```
 
+## Set Task Push Notification Endpoint
+
+The Set Task Push Notification endpoint allows clients to configure push notifications for a task.
+
+```kotlin
+// Create a TaskPushNotificationConfig object
+val config = TaskPushNotificationConfig(
+    id = "task_12345",
+    pushNotificationConfig = PushNotificationConfig(
+        url = "https://example.com/callback",
+        token = "abc.def.jk",
+        authentication = AuthenticationInfo(
+            schemes = listOf("Bearer"),
+        ),
+    ),
+)
+
+// Configure the mock server to respond with the config
+a2aServer.setTaskPushNotification() responds {
+    id = 1
+    result = config
+}
+```
+
 ## Making Requests to the Mock Server
 
 You can use any HTTP client to make requests to the mock server. Here's how to create a Ktor client for A2A:
@@ -412,6 +436,40 @@ val response = a2aClient
 // Parse the response into a CancelTaskResponse object
 val body = response.body<String>()
 val payload = Json.decodeFromString<CancelTaskResponse>(body)
+```
+
+### Set Task Push Notification Endpoint Client Example
+
+```kotlin
+// Create a TaskPushNotificationConfig object
+val config = TaskPushNotificationConfig(
+    id = "task_12345",
+    pushNotificationConfig = PushNotificationConfig(
+        url = "https://example.com/callback",
+        token = "abc.def.jk",
+        authentication = AuthenticationInfo(
+            schemes = listOf("Bearer"),
+        ),
+    ),
+)
+
+// Create a SetTaskPushNotificationRequest object
+val jsonRpcRequest = SetTaskPushNotificationRequest(
+    id = "1",
+    params = config,
+)
+
+// Make a POST request to the Set Task Push Notification endpoint
+val response = a2aClient
+    .post("/") {
+        contentType(ContentType.Application.Json)
+        setBody(Json.encodeToString(jsonRpcRequest))
+    }.call
+    .response
+
+// Parse the response into a SetTaskPushNotificationResponse object
+val body = response.body<String>()
+val payload = Json.decodeFromString<SetTaskPushNotificationResponse>(body)
 ```
 
 ## Verifying Requests


### PR DESCRIPTION
- feat(set-task-push-notification): add support for managing task push notifications

    Introduced new functionality to send and handle task push notification configurations, including supporting request and response structures. Added a building step, response specification, and test cases for proper implementation.

- docs(ai-mocks): add Set Task Push Notification endpoint docs 

    Added detailed documentation for the Set Task Push Notification endpoint, including Kotlin examples for configuration and client usage.

- docs(a2s): restructure endpoint documentation 

    Added `Server Configuration` and `Client Example` sections for all endpoints to improve clarity and organization.
    Moved HTTP client setup to a dedicated section for better visibility and reintroduced missing details for Cancel Task and Set Task Push Notification endpoints.