### PR TITLE
A2A: Support Get Task Push Notification endpoint

### DIFF
--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskPushNotificationRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskPushNotificationRequest.kt
@@ -31,12 +31,9 @@ public data class GetTaskPushNotificationRequest(
     val params: TaskIdParams,
 ) : A2ARequest {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
-        require(method == cg_str1) { "method not constant value $cg_str1 - $method" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "2.0"
-        private const val cg_str1 = "tasks/pushNotification/get"
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
+        require(method == "tasks/pushNotification/get") {
+            "method not constant value \"tasks/pushNotification/get\" - $method"
+        }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskPushNotificationResponse.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskPushNotificationResponse.kt
@@ -30,10 +30,6 @@ public data class GetTaskPushNotificationResponse(
     val error: JSONRPCError? = null,
 ) {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "2.0"
+        require(jsonrpc == "2.0") { "jsonrpc not constant value '2.0' - $jsonrpc" }
     }
 }

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetTaskPushNotificationBuildingStep.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetTaskPushNotificationBuildingStep.kt
@@ -1,31 +1,31 @@
 package me.kpavlov.aimocks.a2a
 
-import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationRequest
-import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationResponse
+import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationRequest
+import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationResponse
 import me.kpavlov.aimocks.core.AbstractBuildingStep
 import me.kpavlov.mokksy.BuildingStep
 import me.kpavlov.mokksy.MokksyServer
 
-public class SetTaskPushNotificationBuildingStep(
+public class GetTaskPushNotificationBuildingStep(
     mokksy: MokksyServer,
-    buildingStep: BuildingStep<SetTaskPushNotificationRequest>,
+    buildingStep: BuildingStep<GetTaskPushNotificationRequest>,
 ) : AbstractBuildingStep<
-        SetTaskPushNotificationRequest,
-        SetTaskPushNotificationResponseSpecification,
+        GetTaskPushNotificationRequest,
+        GetTaskPushNotificationResponseSpecification,
     >(
         mokksy,
         buildingStep,
     ) {
-    override infix fun responds(block: SetTaskPushNotificationResponseSpecification.() -> Unit) {
-        buildingStep.respondsWith<SetTaskPushNotificationResponse> {
+    override infix fun responds(block: GetTaskPushNotificationResponseSpecification.() -> Unit) {
+        buildingStep.respondsWith<GetTaskPushNotificationResponse> {
             val requestBody = request.body
             val responseDefinition = this.build()
             val responseSpecification =
-                SetTaskPushNotificationResponseSpecification(responseDefinition)
+                GetTaskPushNotificationResponseSpecification(responseDefinition)
             block.invoke(responseSpecification)
             val config = requireNotNull(responseSpecification.result) { "Task must be defined" }
             body =
-                SetTaskPushNotificationResponse(
+                GetTaskPushNotificationResponse(
                     id = responseSpecification.id ?: requestBody.id,
                     result = config,
                 )

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetTaskPushNotificationResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetTaskPushNotificationResponseSpecification.kt
@@ -1,0 +1,18 @@
+package me.kpavlov.aimocks.a2a
+
+import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationRequest
+import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationResponse
+import me.kpavlov.aimocks.a2a.model.RequestId
+import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfig
+import me.kpavlov.aimocks.core.ResponseSpecification
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
+import kotlin.time.Duration
+
+public class GetTaskPushNotificationResponseSpecification(
+    response: AbstractResponseDefinition<GetTaskPushNotificationResponse>,
+    public var id: RequestId? = null,
+    public var result: TaskPushNotificationConfig? = null,
+    public var delay: Duration = Duration.ZERO,
+) : ResponseSpecification<GetTaskPushNotificationRequest, GetTaskPushNotificationResponse>(
+        response = response,
+    )

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
@@ -3,6 +3,7 @@ package me.kpavlov.aimocks.a2a
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import me.kpavlov.aimocks.a2a.model.CancelTaskRequest
+import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationRequest
 import me.kpavlov.aimocks.a2a.model.GetTaskRequest
 import me.kpavlov.aimocks.a2a.model.SendTaskRequest
 import me.kpavlov.aimocks.a2a.model.SendTaskStreamingRequest
@@ -231,6 +232,23 @@ public open class MockAgentServer(
                 }
 
         return GetTaskBuildingStep(
+            buildingStep = requestStep,
+            mokksy = mokksy,
+        )
+    }
+
+    @JvmOverloads
+    public fun getTaskPushNotification(name: String? = null): GetTaskPushNotificationBuildingStep {
+        val requestStep =
+            mokksy
+                .post(name = name, requestType = GetTaskPushNotificationRequest::class) {
+                    path("/")
+                    bodyMatchesPredicate {
+                        it?.method == "tasks/pushNotification/get"
+                    }
+                }
+
+        return GetTaskPushNotificationBuildingStep(
             buildingStep = requestStep,
             mokksy = mokksy,
         )

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/GetTaskPushNotificationTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/GetTaskPushNotificationTest.kt
@@ -1,0 +1,75 @@
+package me.kpavlov.aimocks.a2a
+
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.equals.shouldBeEqual
+import io.ktor.client.call.body
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import me.kpavlov.aimocks.a2a.model.AuthenticationInfo
+import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationRequest
+import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationResponse
+import me.kpavlov.aimocks.a2a.model.PushNotificationConfig
+import me.kpavlov.aimocks.a2a.model.TaskId
+import me.kpavlov.aimocks.a2a.model.TaskIdParams
+import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfig
+import kotlin.test.Test
+
+internal class GetTaskPushNotificationTest : AbstractTest() {
+    /**
+     * https://github.com/google/A2A/blob/gh-pages/documentation.md#send-a-task
+     */
+    @Test
+    fun `Should get TaskPushNotification config`() =
+        runTest {
+            val taskId: TaskId = "task_12345"
+            val config =
+                TaskPushNotificationConfig(
+                    id = taskId,
+                    pushNotificationConfig =
+                        PushNotificationConfig(
+                            url = "https://example.com/callback",
+                            token = "abc.def.jk",
+                            authentication =
+                                AuthenticationInfo(
+                                    schemes = listOf("Bearer"),
+                                ),
+                        ),
+                )
+
+            a2aServer.getTaskPushNotification() responds {
+                id = 1
+                result = config
+            }
+
+            val response =
+                a2aClient
+                    .post("/") {
+                        val jsonRpcRequest =
+                            GetTaskPushNotificationRequest(
+                                id = "1",
+                                params =
+                                    TaskIdParams(
+                                        id = taskId,
+                                    ),
+                            )
+                        contentType(ContentType.Application.Json)
+                        setBody(Json.encodeToString(jsonRpcRequest))
+                    }.call
+                    .response
+
+            response.status.shouldBeEqual(HttpStatusCode.OK)
+            val body = response.body<String>()
+            logger.info { "body = $body" }
+            val payload = Json.decodeFromString<GetTaskPushNotificationResponse>(body)
+            payload shouldBeEqualToComparingFields
+                GetTaskPushNotificationResponse(
+                    id = 1,
+                    result = config,
+                )
+        }
+}

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/SetTaskPushNotificationTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/SetTaskPushNotificationTest.kt
@@ -18,12 +18,12 @@ import me.kpavlov.aimocks.a2a.model.TaskId
 import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfig
 import kotlin.test.Test
 
-internal class SetTaskPushNotoficationTest : AbstractTest() {
+internal class SetTaskPushNotificationTest : AbstractTest() {
     /**
      * https://github.com/google/A2A/blob/gh-pages/documentation.md#send-a-task
      */
     @Test
-    fun `Should send task`() =
+    fun `Should set TaskPushNotification config`() =
         runTest {
             val taskId: TaskId = "task_12345"
             val config =


### PR DESCRIPTION
# A2A: Support Get Task Push Notification endpoint

- feat(a2a): implement GetTaskPushNotification support 

    Added functionality to handle `GetTaskPushNotification` operations,
    including request/response models, server integration, documentation and tests.
    This introduces the ability to retrieve push notification configurations
    for specific tasks. Add 
