### PR TITLE
A2A: Builders

### DIFF
--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/A2ARequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/A2ARequest.kt
@@ -19,14 +19,8 @@ public interface A2ARequest {
         val params: TaskSendParams,
     ) : A2ARequest {
         init {
-            require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
-            require(method == cg_str1) { "method not constant value $cg_str1 - $method" }
+            require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
+            require(method == "tasks/send") { "method not constant value tasks/send - $method" }
         }
-    }
-
-    private companion object {
-        @Suppress("ktlint:standard:property-naming")
-        private const val cg_str0 = "2.0"
-        private const val cg_str1 = "tasks/send"
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentAuthentication.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentAuthentication.kt
@@ -20,4 +20,15 @@ public data class AgentAuthentication(
     val schemes: List<String>,
     @SerialName("credentials")
     val credentials: String? = null,
-)
+) {
+    public companion object {
+        /**
+         * Creates a new AgentAuthentication using the DSL builder.
+         *
+         * @param init The lambda to configure the agent authentication.
+         * @return A new AgentAuthentication instance.
+         */
+        public fun build(init: AgentAuthenticationBuilder.() -> Unit): AgentAuthentication =
+            AgentAuthenticationBuilder().apply(init).build()
+    }
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentAuthenticationBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentAuthenticationBuilder.kt
@@ -1,0 +1,45 @@
+package me.kpavlov.aimocks.a2a.model
+
+/**
+ * Builder class for creating [AgentAuthentication] instances.
+ *
+ * This builder provides a fluent API for creating AgentAuthentication objects,
+ * making it easier to construct complex authentication configurations.
+ *
+ * Example usage:
+ * ```kotlin
+ * val auth = AgentAuthenticationBuilder()
+ *     .schemes(listOf("oauth2", "api_key"))
+ *     .credentials("some-credentials-info")
+ *     .build()
+ * ```
+ */
+public class AgentAuthenticationBuilder {
+    public var schemes: List<String> = emptyList()
+    public var credentials: String? = null
+
+    /**
+     * Builds an [AgentAuthentication] instance with the configured parameters.
+     *
+     * @return A new [AgentAuthentication] instance.
+     * @throws IllegalArgumentException If required parameters are missing.
+     */
+    public fun build(): AgentAuthentication {
+        require(schemes.isNotEmpty()) { "At least one authentication scheme is required" }
+
+        return AgentAuthentication(
+            schemes = schemes,
+            credentials = credentials,
+        )
+    }
+}
+
+/**
+ * Creates a new instance of an AgentAuthentication using the provided configuration block.
+ *
+ * @param block A configuration block for building an AgentAuthentication instance using the AgentAuthenticationBuilder.
+ * @return A newly created AgentAuthentication instance.
+ */
+public fun AgentAuthentication.Companion.create(
+    block: AgentAuthenticationBuilder.() -> Unit,
+): AgentAuthentication = AgentAuthenticationBuilder().apply(block).build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentCapabilities.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentCapabilities.kt
@@ -22,4 +22,15 @@ public data class AgentCapabilities(
     val pushNotifications: Boolean = false,
     @SerialName("stateTransitionHistory")
     val stateTransitionHistory: Boolean = false,
-)
+) {
+    public companion object {
+        /**
+         * Creates a new AgentCapabilities using the DSL builder.
+         *
+         * @param init The lambda to configure the agent capabilities.
+         * @return A new AgentCapabilities instance.
+         */
+        public fun build(init: AgentCapabilitiesBuilder.() -> Unit): AgentCapabilities =
+            AgentCapabilitiesBuilder().apply(init).build()
+    }
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentCapabilitiesBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentCapabilitiesBuilder.kt
@@ -1,0 +1,44 @@
+package me.kpavlov.aimocks.a2a.model
+
+/**
+ * Builder class for creating [AgentCapabilities] instances.
+ *
+ * This builder provides a fluent API for creating AgentCapabilities objects,
+ * making it easier to configure agent capabilities.
+ *
+ * Example usage:
+ * ```kotlin
+ * val capabilities = AgentCapabilitiesBuilder()
+ *     .streaming(true)
+ *     .pushNotifications(true)
+ *     .stateTransitionHistory(false)
+ *     .build()
+ * ```
+ */
+public class AgentCapabilitiesBuilder {
+    public var streaming: Boolean = false
+    public var pushNotifications: Boolean = false
+    public var stateTransitionHistory: Boolean = false
+
+    /**
+     * Builds an [AgentCapabilities] instance with the configured parameters.
+     *
+     * @return A new [AgentCapabilities] instance.
+     */
+    public fun build(): AgentCapabilities =
+        AgentCapabilities(
+            streaming = streaming,
+            pushNotifications = pushNotifications,
+            stateTransitionHistory = stateTransitionHistory,
+        )
+}
+
+/**
+ * Creates a new instance of an AgentCapabilities using the provided configuration block.
+ *
+ * @param block A configuration block for building an AgentCapabilities instance using the AgentCapabilitiesBuilder.
+ * @return A newly created AgentCapabilities instance.
+ */
+public fun AgentCapabilities.Companion.create(
+    block: AgentCapabilitiesBuilder.() -> Unit,
+): AgentCapabilities = AgentCapabilitiesBuilder().apply(block).build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentCardBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentCardBuilder.kt
@@ -35,6 +35,18 @@ public class AgentCardBuilder {
             skills = skills!!,
         )
     }
+
+    public fun provider(block: AgentProviderBuilder.() -> Unit) {
+        provider = AgentProviderBuilder().apply(block).build()
+    }
+
+    public fun authentication(block: AgentAuthenticationBuilder.() -> Unit) {
+        authentication = AgentAuthenticationBuilder().apply(block).build()
+    }
+
+    public fun capabilities(block: AgentCapabilitiesBuilder.() -> Unit) {
+        capabilities = AgentCapabilitiesBuilder().apply(block).build()
+    }
 }
 
 // Extension function for convenient creation

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentProvider.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentProvider.kt
@@ -20,4 +20,15 @@ public data class AgentProvider(
     val organization: String,
     @SerialName("url")
     val url: String? = null,
-)
+) {
+    public companion object {
+        /**
+         * Creates a new AgentProvider using the DSL builder.
+         *
+         * @param init The lambda to configure the agent provider.
+         * @return A new AgentProvider instance.
+         */
+        public fun build(init: AgentProviderBuilder.() -> Unit): AgentProvider =
+            AgentProviderBuilder().apply(init).build()
+    }
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentProviderBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentProviderBuilder.kt
@@ -1,0 +1,44 @@
+package me.kpavlov.aimocks.a2a.model
+
+/**
+ * Builder class for creating [AgentProvider] instances.
+ *
+ * This builder provides a fluent API for creating AgentProvider objects,
+ * making it easier to configure agent providers.
+ *
+ * Example usage:
+ * ```kotlin
+ * val provider = AgentProviderBuilder()
+ *     .organization("Example Organization")
+ *     .url("https://example.org")
+ *     .build()
+ * ```
+ */
+public class AgentProviderBuilder {
+    public var organization: String? = null
+    public var url: String? = null
+
+    /**
+     * Builds an [AgentProvider] instance with the configured parameters.
+     *
+     * @return A new [AgentProvider] instance.
+     * @throws IllegalArgumentException If required parameters are missing.
+     */
+    public fun build(): AgentProvider {
+        requireNotNull(organization) { "Organization is required" }
+
+        return AgentProvider(
+            organization = organization!!,
+            url = url,
+        )
+    }
+}
+
+/**
+ * Creates a new instance of an AgentProvider using the provided configuration block.
+ *
+ * @param block A configuration block for building an AgentProvider instance using the AgentProviderBuilder.
+ * @return A newly created AgentProvider instance.
+ */
+public fun AgentProvider.Companion.create(block: AgentProviderBuilder.() -> Unit): AgentProvider =
+    AgentProviderBuilder().apply(block).build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentSkill.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentSkill.kt
@@ -30,4 +30,15 @@ public data class AgentSkill(
     val inputModes: List<String>? = null,
     @SerialName("outputModes")
     val outputModes: List<String>? = null,
-)
+) {
+    public companion object {
+        /**
+         * Creates a new AgentSkill using the DSL builder.
+         *
+         * @param init The lambda to configure the agent skill.
+         * @return A new AgentSkill instance.
+         */
+        public fun build(init: AgentSkillBuilder.() -> Unit): AgentSkill =
+            AgentSkillBuilder().apply(init).build()
+    }
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentSkillBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentSkillBuilder.kt
@@ -1,0 +1,60 @@
+package me.kpavlov.aimocks.a2a.model
+
+/**
+ * Builder class for creating [AgentSkill] instances.
+ *
+ * This builder provides a fluent API for creating AgentSkill objects,
+ * making it easier to configure agent skills.
+ *
+ * Example usage:
+ * ```kotlin
+ * val skill = AgentSkillBuilder()
+ *     .id("skill-123")
+ *     .name("Example Skill")
+ *     .description("This is an example skill")
+ *     .tags(listOf("example", "demo"))
+ *     .examples(listOf("Example usage 1", "Example usage 2"))
+ *     .inputModes(listOf("text"))
+ *     .outputModes(listOf("text"))
+ *     .build()
+ * ```
+ */
+public class AgentSkillBuilder {
+    public var id: String? = null
+    public var name: String? = null
+    public var description: String? = null
+    public var tags: List<String>? = null
+    public var examples: List<String>? = null
+    public var inputModes: List<String>? = null
+    public var outputModes: List<String>? = null
+
+    /**
+     * Builds an [AgentSkill] instance with the configured parameters.
+     *
+     * @return A new [AgentSkill] instance.
+     * @throws IllegalArgumentException If required parameters are missing.
+     */
+    public fun build(): AgentSkill {
+        requireNotNull(id) { "Skill ID is required" }
+        requireNotNull(name) { "Skill name is required" }
+
+        return AgentSkill(
+            id = id!!,
+            name = name!!,
+            description = description,
+            tags = tags,
+            examples = examples,
+            inputModes = inputModes,
+            outputModes = outputModes,
+        )
+    }
+}
+
+/**
+ * Creates a new instance of an AgentSkill using the provided configuration block.
+ *
+ * @param block A configuration block for building an AgentSkill instance using the AgentSkillBuilder.
+ * @return A newly created AgentSkill instance.
+ */
+public fun AgentSkill.Companion.create(block: AgentSkillBuilder.() -> Unit): AgentSkill =
+    AgentSkillBuilder().apply(block).build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/Artifact.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/Artifact.kt
@@ -11,7 +11,6 @@
  */
 package me.kpavlov.aimocks.a2a.model
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -22,19 +21,26 @@ public data class Artifact(
     val name: String? = null,
     @SerialName("description")
     val description: String? = null,
-    @Contextual
     @SerialName("parts")
     val parts: List<Part>,
     @SerialName("index")
     @EncodeDefault
     val index: Long = 0,
-    @Contextual
     @SerialName("append")
     val append: Boolean? = null,
-    @Contextual
     @SerialName("lastChunk")
     val lastChunk: Boolean? = null,
-    @Contextual
     @SerialName("metadata")
     val metadata: Metadata? = null,
-)
+) {
+    public companion object {
+        /**
+         * Creates a new Artifact using the DSL builder.
+         *
+         * @param init The lambda to configure the artifact.
+         * @return A new Artifact instance.
+         */
+        public fun build(init: ArtifactBuilder.() -> Unit): Artifact =
+            ArtifactBuilder().apply(init).build()
+    }
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/CancelTaskRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/CancelTaskRequest.kt
@@ -11,14 +11,10 @@
  */
 package me.kpavlov.aimocks.a2a.model
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
-
-private const val cg_str0 = "2.0"
-private const val cg_str1 = "tasks/cancel"
 
 @Serializable
 public data class CancelTaskRequest(
@@ -31,12 +27,11 @@ public data class CancelTaskRequest(
     @SerialName("method")
     @EncodeDefault
     val method: String = "tasks/cancel",
-    @Contextual
     @SerialName("params")
     val params: TaskIdParams,
 ) : A2ARequest {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
-        require(method == cg_str1) { "method not constant value $cg_str1 - $method" }
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
+        require(method == "tasks/cancel") { "method not constant value tasks/cancel - $method" }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/FileContent.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/FileContent.kt
@@ -17,8 +17,8 @@ import me.kpavlov.aimocks.a2a.model.serializers.ByteArrayAsBase64Serializer
 
 /**
  * Represents the content of a file, either as base64 encoded bytes or a URI.
-
-Ensures that either 'bytes' or 'uri' is provided, but not both.
+ *
+ * Either 'bytes' or 'uri' should be provided, but not both.
  */
 @Serializable
 public data class FileContent(
@@ -32,7 +32,7 @@ public data class FileContent(
     @SerialName("uri")
     val uri: String? = null,
 ) {
-    override fun equals(other: Any?): Boolean {
+    public override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
@@ -45,10 +45,18 @@ public data class FileContent(
         return true
     }
 
-    override fun hashCode(): Int {
+    public override fun hashCode(): Int {
         var result = name?.hashCode() ?: 0
         result = 31 * result + (mimeType?.hashCode() ?: 0)
         result = 31 * result + (uri?.hashCode() ?: 0)
         return result
     }
+
+    public override fun toString(): String =
+        "FileContent(" +
+            "name=$name, " +
+            "uri=$uri, " +
+            "mimeType=$mimeType, " +
+            "bytes=${if (bytes != null) "${bytes.size} bytes" else "null"}" +
+            ")"
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/FileContent.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/FileContent.kt
@@ -31,4 +31,24 @@ public data class FileContent(
     val bytes: ByteArray? = null,
     @SerialName("uri")
     val uri: String? = null,
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as FileContent
+
+        if (name != other.name) return false
+        if (mimeType != other.mimeType) return false
+        if (uri != other.uri) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name?.hashCode() ?: 0
+        result = 31 * result + (mimeType?.hashCode() ?: 0)
+        result = 31 * result + (uri?.hashCode() ?: 0)
+        return result
+    }
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskRequest.kt
@@ -11,35 +11,27 @@
  */
 package me.kpavlov.aimocks.a2a.model
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 
-private const val cg_str0 = "2.0"
-private const val cg_str1 = "tasks/get"
-
 @Serializable
 public data class GetTaskRequest(
-    @Contextual
     @SerialName("jsonrpc")
     @EncodeDefault
     val jsonrpc: String = "2.0",
-    @Contextual
     @SerialName("id")
     @Serializable(with = RequestIdSerializer::class)
     val id: RequestId? = null,
-    @Contextual
     @SerialName("method")
     @EncodeDefault
     val method: String = "tasks/get",
-    @Contextual
     @SerialName("params")
     val params: TaskQueryParams,
 ) : A2ARequest {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
-        require(method == cg_str1) { "method not constant value $cg_str1 - $method" }
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
+        require(method == "tasks/get") { "method not constant value tasks/get - $method" }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskResponse.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskResponse.kt
@@ -16,8 +16,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 
-private const val cg_str0 = "2.0"
-
 @Serializable
 public data class GetTaskResponse(
     @SerialName("jsonrpc")
@@ -32,6 +30,6 @@ public data class GetTaskResponse(
     val error: JSONRPCError? = null,
 ) {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/InternalError.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/InternalError.kt
@@ -18,11 +18,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class InternalError(
     /** Error code */
-    @Contextual
     @SerialName("code")
     val code: Int = -32603,
     /** A short description of the error */
-    @Contextual
     @SerialName("message")
     val message: String = "Internal error",
     @Contextual
@@ -31,10 +29,8 @@ public data class InternalError(
 ) {
     init {
         require(code == -32603) { "code not constant value -32603 - $code" }
-        require(message == cg_str0) { "message not constant value $cg_str0 - $message" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "Internal error"
+        require(
+            message == "Internal error",
+        ) { "message not constant value Internal error - $message" }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/InvalidParamsError.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/InvalidParamsError.kt
@@ -18,11 +18,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class InvalidParamsError(
     /** Error code */
-    @Contextual
     @SerialName("code")
     val code: Int = -32602,
     /** A short description of the error */
-    @Contextual
     @SerialName("message")
     val message: String = "Invalid parameters",
     @Contextual

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/InvalidRequestError.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/InvalidRequestError.kt
@@ -31,10 +31,8 @@ public data class InvalidRequestError(
 ) {
     init {
         require(code == -32600) { "code not constant value -32600 - $code" }
-        require(message == cg_str0) { "message not constant value $cg_str0 - $message" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "Request payload validation error"
+        require(message == "Request payload validation error") {
+            "message not constant value Request payload validation error - $message"
+        }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/JSONParseError.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/JSONParseError.kt
@@ -19,12 +19,10 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class JSONParseError(
     /** Error code */
-    @Contextual
     @SerialName("code")
     @EncodeDefault
     val code: Int = -32700,
     /** A short description of the error */
-    @Contextual
     @SerialName("message")
     val message: String = "Invalid JSON payload",
     @Contextual
@@ -33,10 +31,8 @@ public data class JSONParseError(
 ) {
     init {
         require(code == -32700) { "code not constant value -32700 - $code" }
-        require(message == cg_str0) { "message not constant value $cg_str0 - $message" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "Invalid JSON payload"
+        require(message == "Invalid JSON payload") {
+            "message not constant value Invalid JSON payload - $message"
+        }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/JSONRPCMessage.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/JSONRPCMessage.kt
@@ -11,7 +11,6 @@
  */
 package me.kpavlov.aimocks.a2a.model
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -19,20 +18,14 @@ import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 
 @Serializable
 public data class JSONRPCMessage(
-    @Contextual
     @SerialName("jsonrpc")
     @EncodeDefault
     val jsonrpc: String = "2.0",
-    @Contextual
     @SerialName("id")
     @Serializable(with = RequestIdSerializer::class)
     val id: RequestId? = null,
 ) {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "2.0"
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/JSONRPCRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/JSONRPCRequest.kt
@@ -19,15 +19,12 @@ import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 
 @Serializable
 public data class JSONRPCRequest(
-    @Contextual
     @SerialName("jsonrpc")
     @EncodeDefault
     val jsonrpc: String = "2.0",
-    @Contextual
     @SerialName("id")
     @Serializable(with = RequestIdSerializer::class)
     val id: RequestId? = null,
-    @Contextual
     @SerialName("method")
     val method: String,
     @Contextual
@@ -35,13 +32,9 @@ public data class JSONRPCRequest(
     val params: Params? = null,
 ) {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
     }
 
     @Serializable
     public open class Params
-
-    private companion object {
-        private const val cg_str0 = "2.0"
-    }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/JSONRPCResponse.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/JSONRPCResponse.kt
@@ -19,26 +19,19 @@ import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 
 @Serializable
 public data class JSONRPCResponse(
-    @Contextual
     @SerialName("jsonrpc")
     @EncodeDefault
     val jsonrpc: String = "2.0",
-    @Contextual
     @SerialName("id")
     @Serializable(with = RequestIdSerializer::class)
     val id: RequestId? = null,
     @Contextual
     @SerialName("result")
     val result: Any? = null,
-    @Contextual
     @SerialName("error")
     val error: JSONRPCError? = null,
 ) {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "2.0"
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/Message.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/Message.kt
@@ -17,10 +17,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 public data class Message(
-    @Contextual
     @SerialName("role")
     val role: Role,
-    @Contextual
     @SerialName("parts")
     val parts: List<Part>,
     @Contextual
@@ -32,5 +30,16 @@ public data class Message(
     public enum class Role {
         user,
         agent,
+    }
+
+    public companion object {
+        /**
+         * Creates a new Message using the DSL builder.
+         *
+         * @param init The lambda to configure the message.
+         * @return A new Message instance.
+         */
+        public fun build(init: MessageBuilder.() -> Unit): Message =
+            MessageBuilder().apply(init).build()
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/MethodNotFoundError.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/MethodNotFoundError.kt
@@ -18,11 +18,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class MethodNotFoundError(
     /** Error code */
-    @Contextual
     @SerialName("code")
     val code: Int = -32601,
     /** A short description of the error */
-    @Contextual
     @SerialName("message")
     val message: String = "Method not found",
     @Contextual
@@ -31,10 +29,8 @@ public data class MethodNotFoundError(
 ) {
     init {
         require(code == -32601) { "code not constant value -32601 - $code" }
-        require(message == cg_str0) { "message not constant value $cg_str0 - $message" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "Method not found"
+        require(
+            message == "Method not found",
+        ) { "message not constant value Method not found - $message" }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/Part.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/Part.kt
@@ -3,5 +3,4 @@ package me.kpavlov.aimocks.a2a.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-// @JsonClassDiscriminator("type")
 public sealed interface Part

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationConfig.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationConfig.kt
@@ -11,19 +11,33 @@
  */
 package me.kpavlov.aimocks.a2a.model
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class PushNotificationConfig(
-    @Contextual
     @SerialName("url")
     val url: String,
-    @Contextual
     @SerialName("token")
     val token: String? = null,
-    @Contextual
     @SerialName("authentication")
     val authentication: AuthenticationInfo? = null,
-)
+) {
+    public companion object {
+        /**
+         * Creates a new PushNotificationConfig using the DSL builder.
+         *
+         * @param init The lambda to configure the push notification config.
+         * @return A new PushNotificationConfig instance.
+         */
+        public fun build(init: PushNotificationConfigBuilder.() -> Unit): PushNotificationConfig =
+            PushNotificationConfigBuilder().apply(init).build()
+    }
+
+    override fun toString(): String =
+        "PushNotificationConfig(" +
+            "url='$url', " +
+            "authentication=$authentication, " +
+            "token=${if (token != null) "[REDACTED]" else "null"}" +
+            ")"
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationConfigBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationConfigBuilder.kt
@@ -1,0 +1,48 @@
+package me.kpavlov.aimocks.a2a.model
+
+/**
+ * Builder class for creating [PushNotificationConfig] instances.
+ *
+ * This builder provides a fluent API for creating PushNotificationConfig objects,
+ * making it easier to configure push notification settings.
+ *
+ * Example usage:
+ * ```kotlin
+ * val config = PushNotificationConfigBuilder()
+ *     .url("https://example.org/notifications")
+ *     .token("auth-token")
+ *     .build()
+ * ```
+ */
+public class PushNotificationConfigBuilder {
+    public var url: String? = null
+    public var token: String? = null
+    public var authentication: AuthenticationInfo? = null
+
+    /**
+     * Builds a [PushNotificationConfig] instance with the configured parameters.
+     *
+     * @return A new [PushNotificationConfig] instance.
+     * @throws IllegalArgumentException If required parameters are missing.
+     */
+    public fun build(): PushNotificationConfig {
+        requireNotNull(url) { "URL is required" }
+
+        return PushNotificationConfig(
+            url = url!!,
+            token = token,
+            authentication = authentication,
+        )
+    }
+}
+
+/**
+ * Creates a new instance of a PushNotificationConfig using the provided configuration block.
+ *
+ * @param block A configuration block for building a PushNotificationConfig instance
+ * using the PushNotificationConfigBuilder.
+ * @return A newly created PushNotificationConfig instance.
+ */
+public fun PushNotificationConfig.Companion.create(
+    block: PushNotificationConfigBuilder.() -> Unit,
+): PushNotificationConfig = build(block)

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationNotSupportedError.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationNotSupportedError.kt
@@ -7,11 +7,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class PushNotificationNotSupportedError(
     /** Error code */
-    @Contextual
     @SerialName("code")
     val code: Int = -32003,
     /** A short description of the error */
-    @Contextual
     @SerialName("message")
     val message: String = "Push Notification is not supported",
     @Contextual
@@ -20,11 +18,8 @@ public data class PushNotificationNotSupportedError(
 ) {
     init {
         require(code == -32003) { "code not constant value -32003 - $code" }
-        require(message == cg_str0) { "message not constant value $cg_str0 - $message" }
-    }
-
-    private companion object {
-        @Suppress("ktlint:standard:property-naming")
-        private const val cg_str0 = "Push Notification is not supported"
+        require(message == "Push Notification is not supported") {
+            "message not constant value Push Notification is not supported - $message"
+        }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskRequest.kt
@@ -16,9 +16,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 
-private const val cg_str0 = "2.0"
-private const val cg_str1 = "tasks/send"
-
 @Serializable
 public data class SendTaskRequest(
     @SerialName("jsonrpc")
@@ -34,7 +31,18 @@ public data class SendTaskRequest(
     val params: TaskSendParams,
 ) : A2ARequest {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
-        require(method == cg_str1) { "method not constant value $cg_str1 - $method" }
+        require(jsonrpc == "2.0") { "jsonrpc not constant value \"2.0\" - $jsonrpc" }
+        require(method == "tasks/send") { "method not constant value \"tasks/send\" - $method" }
+    }
+
+    public companion object {
+        /**
+         * Creates a new SendTaskRequest using the DSL builder.
+         *
+         * @param init The lambda to configure the send task request.
+         * @return A new SendTaskRequest instance.
+         */
+        public fun build(init: SendTaskRequestBuilder.() -> Unit): SendTaskRequest =
+            SendTaskRequestBuilder().apply(init).build()
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskRequestBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskRequestBuilder.kt
@@ -1,0 +1,60 @@
+package me.kpavlov.aimocks.a2a.model
+
+/**
+ * Builder class for creating [SendTaskRequest] instances.
+ *
+ * This builder provides a fluent API for creating SendTaskRequest objects,
+ * making it easier to configure send task requests.
+ *
+ * Example usage:
+ * ```kotlin
+ * val request = SendTaskRequestBuilder()
+ *     .id("request-123")
+ *     .params {
+ *         id = "task-123"
+ *         message {
+ *             role = Message.Role.user
+ *             textPart("Hello, how can I help you?")
+ *         }
+ *     }
+ *     .build()
+ * ```
+ */
+public class SendTaskRequestBuilder {
+    public var id: String? = null
+    public var params: TaskSendParams? = null
+
+    /**
+     * Configures the task send params using a DSL.
+     *
+     * @param init The lambda to configure the task send params.
+     */
+    public fun params(init: TaskSendParamsBuilder.() -> Unit) {
+        this.params = TaskSendParams.build(init)
+    }
+
+    /**
+     * Builds a [SendTaskRequest] instance with the configured parameters.
+     *
+     * @return A new [SendTaskRequest] instance.
+     * @throws IllegalArgumentException If required parameters are missing.
+     */
+    public fun build(): SendTaskRequest {
+        requireNotNull(params) { "Params are required" }
+
+        return SendTaskRequest(
+            id = id,
+            params = params!!,
+        )
+    }
+}
+
+/**
+ * Creates a new instance of a SendTaskRequest using the provided configuration block.
+ *
+ * @param block A configuration block for building a SendTaskRequest instance using the SendTaskRequestBuilder.
+ * @return A newly created SendTaskRequest instance.
+ */
+public fun SendTaskRequest.Companion.create(
+    block: SendTaskRequestBuilder.() -> Unit,
+): SendTaskRequest = build(block)

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskStreamingRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskStreamingRequest.kt
@@ -11,14 +11,10 @@
  */
 package me.kpavlov.aimocks.a2a.model
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
-
-private const val cg_str0 = "2.0"
-private const val cg_str1 = "tasks/sendSubscribe"
 
 @Serializable
 public data class SendTaskStreamingRequest(
@@ -31,12 +27,13 @@ public data class SendTaskStreamingRequest(
     @SerialName("method")
     @EncodeDefault
     val method: String = "tasks/sendSubscribe",
-    @Contextual
     @SerialName("params")
     val params: TaskSendParams,
 ) {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
-        require(method == cg_str1) { "method not constant value $cg_str1 - $method" }
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
+        require(method == "tasks/sendSubscribe") {
+            "method not constant value tasks/sendSubscribe - $method"
+        }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskStreamingResponse.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskStreamingResponse.kt
@@ -11,7 +11,6 @@
  */
 package me.kpavlov.aimocks.a2a.model
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.Polymorphic
 import kotlinx.serialization.SerialName
@@ -31,7 +30,6 @@ public data class SendTaskStreamingResponse(
     @Polymorphic
     @Serializable(with = TaskUpdateEventSerializer::class)
     val result: TaskUpdateEvent? = null,
-    @Contextual
     @SerialName("error")
     val error: JSONRPCError? = null,
 ) {

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SetTaskPushNotificationResponse.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SetTaskPushNotificationResponse.kt
@@ -11,7 +11,6 @@
  */
 package me.kpavlov.aimocks.a2a.model
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -27,7 +26,6 @@ public data class SetTaskPushNotificationResponse(
     var id: RequestId? = null,
     @SerialName("result")
     val result: TaskPushNotificationConfig? = null,
-    @Contextual
     @SerialName("error")
     val error: JSONRPCError? = null,
 ) {

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/Task.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/Task.kt
@@ -29,5 +29,13 @@ public data class Task(
     @SerialName("metadata")
     val metadata: Metadata? = null,
 ) {
-    public companion object
+    public companion object {
+        /**
+         * Creates a new Task using the DSL builder.
+         *
+         * @param init The lambda to configure the task.
+         * @return A new Task instance.
+         */
+        public fun build(init: TaskBuilder.() -> Unit): Task = TaskBuilder().apply(init).build()
+    }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskArtifactUpdateEvent.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskArtifactUpdateEvent.kt
@@ -24,4 +24,6 @@ public data class TaskArtifactUpdateEvent(
     val metadata: Metadata? = null,
 ) : TaskUpdateEvent {
     override fun id(): TaskId = id
+
+    public companion object
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskArtifactUpdateEventBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskArtifactUpdateEventBuilder.kt
@@ -1,0 +1,66 @@
+package me.kpavlov.aimocks.a2a.model
+
+public class TaskArtifactUpdateEventBuilder {
+    public var id: TaskId? = null
+    public var artifact: Artifact? = null
+    public var metadata: Metadata? = null
+
+    /**
+     * Sets the id of the task artifact.
+     *
+     * @param id The unique identifier for the task.
+     * @return This builder instance for method chaining.
+     */
+    public fun id(id: TaskId): TaskArtifactUpdateEventBuilder {
+        this.id = id
+        return this
+    }
+
+    /**
+     * Sets the artifact for the event.
+     *
+     * @param artifact The artifact data.
+     * @return This builder instance for method chaining.
+     */
+    public fun artifact(artifact: Artifact): TaskArtifactUpdateEventBuilder {
+        this.artifact = artifact
+        return this
+    }
+
+    /**
+     * Sets the optional metadata for the event.
+     *
+     * @param metadata The metadata associated with the task artifact update.
+     * @return This builder instance for method chaining.
+     */
+    public fun metadata(metadata: Metadata): TaskArtifactUpdateEventBuilder {
+        this.metadata = metadata
+        return this
+    }
+
+    /**
+     * Builds a `TaskArtifactUpdateEvent` instance with the configured parameters.
+     *
+     * @return A newly created `TaskArtifactUpdateEvent`.
+     * @throws IllegalArgumentException If required parameters are missing.
+     */
+    public fun build(): TaskArtifactUpdateEvent {
+        requireNotNull(id) { "Task ID is required" }
+        requireNotNull(artifact) { "Artifact is required" }
+        return TaskArtifactUpdateEvent(
+            id = id!!,
+            artifact = artifact!!,
+            metadata = metadata,
+        )
+    }
+}
+
+/**
+ * Creates a new TaskArtifactUpdateEvent using the DSL builder.
+ *
+ * @param init The lambda to configure the TaskArtifactUpdateEvent.
+ * @return A new TaskArtifactUpdateEvent instance.
+ */
+public fun TaskArtifactUpdateEvent.Companion.create(
+    init: TaskArtifactUpdateEventBuilder.() -> Unit,
+): TaskArtifactUpdateEvent = TaskArtifactUpdateEventBuilder().apply(init).build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskBuilder.kt
@@ -90,6 +90,10 @@ public class TaskBuilder {
             metadata = metadata,
         )
     }
+
+    public fun status(block: TaskStatusBuilder.() -> Unit) {
+        status = TaskStatusBuilder().apply(block).build()
+    }
 }
 
 /**

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskIdParams.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskIdParams.kt
@@ -11,16 +11,13 @@
  */
 package me.kpavlov.aimocks.a2a.model
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class TaskIdParams(
-    @Contextual
     @SerialName("id")
     val id: TaskId,
-    @Contextual
     @SerialName("metadata")
     val metadata: Metadata? = null,
 )

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskNotCancelableError.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskNotCancelableError.kt
@@ -18,11 +18,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class TaskNotCancelableError(
     /** Error code */
-    @Contextual
     @SerialName("code")
     val code: Int = -32002,
     /** A short description of the error */
-    @Contextual
     @SerialName("message")
     val message: String = "Task cannot be canceled",
     @Contextual
@@ -31,10 +29,8 @@ public data class TaskNotCancelableError(
 ) {
     init {
         require(code == -32002) { "code not constant value -32002 - $code" }
-        require(message == cg_str0) { "message not constant value $cg_str0 - $message" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "Task cannot be canceled"
+        require(message == "Task cannot be canceled") {
+            "message not constant value Task cannot be canceled - $message"
+        }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskNotFoundError.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskNotFoundError.kt
@@ -18,11 +18,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class TaskNotFoundError(
     /** Error code */
-    @Contextual
     @SerialName("code")
     val code: Int = -32001,
     /** A short description of the error */
-    @Contextual
     @SerialName("message")
     val message: String = "Task not found",
     @Contextual
@@ -31,10 +29,8 @@ public data class TaskNotFoundError(
 ) {
     init {
         require(code == -32001) { "code not constant value -32001 - $code" }
-        require(message == cg_str0) { "message not constant value $cg_str0 - $message" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "Task not found"
+        require(
+            message == "Task not found",
+        ) { "message not constant value Task not found - $message" }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskPushNotificationConfig.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskPushNotificationConfig.kt
@@ -20,4 +20,16 @@ public data class TaskPushNotificationConfig(
     val id: TaskId,
     @SerialName("pushNotificationConfig")
     val pushNotificationConfig: PushNotificationConfig,
-)
+) {
+    public companion object {
+        /**
+         * Creates a new TaskPushNotificationConfig using the DSL builder.
+         *
+         * @param init The lambda to configure the task push notification config.
+         * @return A new TaskPushNotificationConfig instance.
+         */
+        public fun build(
+            init: TaskPushNotificationConfigBuilder.() -> Unit,
+        ): TaskPushNotificationConfig = TaskPushNotificationConfigBuilder().apply(init).build()
+    }
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskPushNotificationConfigBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskPushNotificationConfigBuilder.kt
@@ -1,0 +1,59 @@
+package me.kpavlov.aimocks.a2a.model
+
+/**
+ * Builder class for creating [TaskPushNotificationConfig] instances.
+ *
+ * This builder provides a fluent API for creating TaskPushNotificationConfig objects,
+ * making it easier to configure task push notification settings.
+ *
+ * Example usage:
+ * ```kotlin
+ * val config = TaskPushNotificationConfigBuilder()
+ *     .id("task-123")
+ *     .pushNotificationConfig {
+ *         url = "https://example.org/notifications"
+ *         token = "auth-token"
+ *     }
+ *     .build()
+ * ```
+ */
+public class TaskPushNotificationConfigBuilder {
+    public var id: String? = null
+    public var pushNotificationConfig: PushNotificationConfig? = null
+
+    /**
+     * Configures the push notification config using a DSL.
+     *
+     * @param init The lambda to configure the push notification config.
+     */
+    public fun pushNotificationConfig(init: PushNotificationConfigBuilder.() -> Unit) {
+        this.pushNotificationConfig = PushNotificationConfig.build(init)
+    }
+
+    /**
+     * Builds a [TaskPushNotificationConfig] instance with the configured parameters.
+     *
+     * @return A new [TaskPushNotificationConfig] instance.
+     * @throws IllegalArgumentException If required parameters are missing.
+     */
+    public fun build(): TaskPushNotificationConfig {
+        requireNotNull(id) { "Task ID is required" }
+        requireNotNull(pushNotificationConfig) { "Push notification config is required" }
+
+        return TaskPushNotificationConfig(
+            id = id!!,
+            pushNotificationConfig = pushNotificationConfig!!,
+        )
+    }
+}
+
+/**
+ * Creates a new instance of a TaskPushNotificationConfig using the provided configuration block.
+ *
+ * @param block A configuration block for building a TaskPushNotificationConfig instance
+ * using the TaskPushNotificationConfigBuilder.
+ * @return A newly created TaskPushNotificationConfig instance.
+ */
+public fun TaskPushNotificationConfig.Companion.create(
+    block: TaskPushNotificationConfigBuilder.() -> Unit,
+): TaskPushNotificationConfig = build(block)

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskQueryParams.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskQueryParams.kt
@@ -17,10 +17,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 public data class TaskQueryParams(
-    @Contextual
     @SerialName("id")
     val id: String,
-    @Contextual
     @SerialName("historyLength")
     val historyLength: Long? = null,
     @Contextual

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskResubscriptionRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskResubscriptionRequest.kt
@@ -11,7 +11,6 @@
  */
 package me.kpavlov.aimocks.a2a.model
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -28,17 +27,13 @@ public data class TaskResubscriptionRequest(
     @SerialName("method")
     @EncodeDefault
     val method: String = "tasks/resubscribe",
-    @Contextual
     @SerialName("params")
     val params: TaskQueryParams,
 ) : A2ARequest {
     init {
-        require(jsonrpc == cg_str0) { "jsonrpc not constant value $cg_str0 - $jsonrpc" }
-        require(method == cg_str1) { "method not constant value $cg_str1 - $method" }
-    }
-
-    private companion object {
-        private const val cg_str0 = "2.0"
-        private const val cg_str1 = "tasks/resubscribe"
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
+        require(
+            method == "tasks/resubscribe",
+        ) { "method not constant value tasks/resubscribe - $method" }
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskSendParams.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskSendParams.kt
@@ -11,13 +11,11 @@
  */
 package me.kpavlov.aimocks.a2a.model
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class TaskSendParams(
-    @Contextual
     @SerialName("id")
     val id: TaskId,
     @SerialName("sessionId")
@@ -30,4 +28,15 @@ public data class TaskSendParams(
     val historyLength: Long? = null,
     @SerialName("metadata")
     val metadata: Metadata? = null,
-)
+) {
+    public companion object {
+        /**
+         * Creates a new TaskSendParams using the DSL builder.
+         *
+         * @param init The lambda to configure the task send params.
+         * @return A new TaskSendParams instance.
+         */
+        public fun build(init: TaskSendParamsBuilder.() -> Unit): TaskSendParams =
+            TaskSendParamsBuilder().apply(init).build()
+    }
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskSendParamsBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskSendParamsBuilder.kt
@@ -1,0 +1,81 @@
+package me.kpavlov.aimocks.a2a.model
+
+/**
+ * Builder class for creating [TaskSendParams] instances.
+ *
+ * This builder provides a fluent API for creating TaskSendParams objects,
+ * making it easier to configure task send parameters.
+ *
+ * Example usage:
+ * ```kotlin
+ * val params = TaskSendParamsBuilder()
+ *     .id("task-123")
+ *     .sessionId("session-456")
+ *     .message {
+ *         role = Message.Role.user
+ *         textPart("Hello, how can I help you?")
+ *     }
+ *     .pushNotification {
+ *         url = "https://example.org/notifications"
+ *         token = "auth-token"
+ *     }
+ *     .historyLength(10)
+ *     .build()
+ * ```
+ */
+public class TaskSendParamsBuilder {
+    public var id: String? = null
+    public var sessionId: String? = null
+    public var message: Message? = null
+    public var pushNotification: PushNotificationConfig? = null
+    public var historyLength: Long? = null
+    public var metadata: Metadata? = null
+
+    /**
+     * Configures the message using a DSL.
+     *
+     * @param init The lambda to configure the message.
+     */
+    public fun message(init: MessageBuilder.() -> Unit) {
+        this.message = Message.build(init)
+    }
+
+    /**
+     * Configures the push notification config using a DSL.
+     *
+     * @param init The lambda to configure the push notification config.
+     */
+    public fun pushNotification(init: PushNotificationConfigBuilder.() -> Unit) {
+        this.pushNotification = PushNotificationConfig.build(init)
+    }
+
+    /**
+     * Builds a [TaskSendParams] instance with the configured parameters.
+     *
+     * @return A new [TaskSendParams] instance.
+     * @throws IllegalArgumentException If required parameters are missing.
+     */
+    public fun build(): TaskSendParams {
+        requireNotNull(id) { "Task ID is required" }
+        requireNotNull(message) { "Message is required" }
+
+        return TaskSendParams(
+            id = id!!,
+            sessionId = sessionId,
+            message = message!!,
+            pushNotification = pushNotification,
+            historyLength = historyLength,
+            metadata = metadata,
+        )
+    }
+}
+
+/**
+ * Creates a new instance of a TaskSendParams using the provided configuration block.
+ *
+ * @param block A configuration block for building a TaskSendParams instance using the TaskSendParamsBuilder.
+ * @return A newly created TaskSendParams instance.
+ */
+public fun TaskSendParams.Companion.create(
+    block: TaskSendParamsBuilder.() -> Unit,
+): TaskSendParams = TaskSendParamsBuilder().apply(block).build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskStatus.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskStatus.kt
@@ -12,19 +12,15 @@
 package me.kpavlov.aimocks.a2a.model
 
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class TaskStatus(
-    @Contextual
     @SerialName("state")
     val state: String,
-    @Contextual
     @SerialName("message")
     val message: Message? = null,
-    @Contextual
     @SerialName("timestamp")
     val timestamp: Instant? = null,
 ) {

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskStatusBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskStatusBuilder.kt
@@ -18,9 +18,9 @@ import kotlinx.datetime.Instant
  * ```
  */
 public class TaskStatusBuilder {
-    private var state: String? = null
-    private var message: Message? = null
-    private var timestamp: Instant? = null
+    public var state: String? = null
+    public var message: Message? = null
+    public var timestamp: Instant? = null
 
     /**
      * Sets the state of the task status.

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/UnsupportedOperationError.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/UnsupportedOperationError.kt
@@ -18,11 +18,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class UnsupportedOperationError(
     /** Error code */
-    @Contextual
     @SerialName("code")
     val code: Int = -32004,
     /** A short description of the error */
-    @Contextual
     @SerialName("message")
     val message: String = "This operation is not supported",
     @Contextual

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/serializers/RequestIdSerializer.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/serializers/RequestIdSerializer.kt
@@ -29,6 +29,7 @@ public class RequestIdSerializer : KSerializer<RequestId?> {
                 // Try to convert to Int first, if not possible, use as String
                 element.intOrNull ?: element.content
             }
+
             else -> throw SerializationException("Unexpected JSON element type: $element")
         }
     }

--- a/ai-mocks-a2a-models/src/commonTest/kotlin/me/kpavlov/aimocks/a2a/model/serializers/TaskUpdateEventSerializerTest.kt
+++ b/ai-mocks-a2a-models/src/commonTest/kotlin/me/kpavlov/aimocks/a2a/model/serializers/TaskUpdateEventSerializerTest.kt
@@ -1,0 +1,107 @@
+package me.kpavlov.aimocks.a2a.model.serializers
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+import me.kpavlov.aimocks.a2a.model.AbstractSerializationTest
+import me.kpavlov.aimocks.a2a.model.TaskArtifactUpdateEvent
+import me.kpavlov.aimocks.a2a.model.TaskStatusUpdateEvent
+import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
+import me.kpavlov.aimocks.a2a.model.TextPart
+import kotlin.test.Test
+
+internal class TaskUpdateEventSerializerTest : AbstractSerializationTest() {
+    @Test
+    fun `Deserialize TaskStatusUpdateEvent as TaskUpdateEvent`() {
+        // language=json
+        val payload =
+            """
+            {
+              "id": "1",
+              "status": {
+                "state": "working",
+                "timestamp":"2025-04-02T16:59:25.331844Z"
+              },
+              "final": false
+            }
+            """.trimIndent()
+
+        // Deserialize as TaskUpdateEvent (polymorphic)
+        val model = Json.decodeFromString<TaskUpdateEvent>(payload)
+
+        // Verify it's the correct subclass
+        model.shouldBeInstanceOf<TaskStatusUpdateEvent>()
+
+        // Verify properties
+        val statusEvent = model
+        statusEvent.id shouldBe "1"
+        statusEvent.status.state shouldBe "working"
+        statusEvent.status.timestamp shouldBe Instant.parse("2025-04-02T16:59:25.331844Z")
+        statusEvent.final shouldBe false
+
+        // Verify serialization
+        val encoded = Json.encodeToString(TaskUpdateEvent.serializer(), model)
+        val decoded = Json.decodeFromString<TaskUpdateEvent>(encoded)
+        decoded.shouldBeInstanceOf<TaskStatusUpdateEvent>()
+    }
+
+    @Test
+    fun `Deserialize TaskArtifactUpdateEvent as TaskUpdateEvent`() {
+        // language=json
+        val payload =
+            """
+            {
+              "id": "1",
+              "artifact": {
+                "parts": [
+                  {"type":"text", "text": "<section 1...>"}
+                ],
+                "index": 0,
+                "append": false,
+                "lastChunk": false
+              }
+            }
+            """.trimIndent()
+
+        // Deserialize as TaskUpdateEvent (polymorphic)
+        val model = Json.decodeFromString<TaskUpdateEvent>(payload)
+
+        // Verify it's the correct subclass
+        model.shouldBeInstanceOf<TaskArtifactUpdateEvent>()
+
+        // Verify properties
+        val artifactEvent = model
+        artifactEvent.id shouldBe "1"
+        artifactEvent.artifact.parts.size shouldBe 1
+        (artifactEvent.artifact.parts[0] as? TextPart)?.text shouldBe "<section 1...>"
+        artifactEvent.artifact.index shouldBe 0
+        artifactEvent.artifact.append shouldBe false
+        artifactEvent.artifact.lastChunk shouldBe false
+
+        // Verify serialization
+        val encoded = Json.encodeToString(TaskUpdateEvent.serializer(), model)
+        val decoded = Json.decodeFromString<TaskUpdateEvent>(encoded)
+        decoded.shouldBeInstanceOf<TaskArtifactUpdateEvent>()
+    }
+
+    @Test
+    fun `Error on invalid JSON without status or artifact`() {
+        // language=json
+        val payload =
+            """
+            {
+              "id": "1"
+            }
+            """.trimIndent()
+
+        // This should throw an exception because it can't determine the subclass
+        try {
+            Json.decodeFromString<TaskUpdateEvent>(payload)
+            throw AssertionError("Expected SerializationException but no exception was thrown")
+        } catch (e: Exception) {
+            // Expected exception
+            e.message?.contains("neither 'artifact' nor 'status' property found") shouldBe true
+        }
+    }
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetTaskPushNotificationBuildingStep.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetTaskPushNotificationBuildingStep.kt
@@ -23,7 +23,10 @@ public class GetTaskPushNotificationBuildingStep(
             val responseSpecification =
                 GetTaskPushNotificationResponseSpecification(responseDefinition)
             block.invoke(responseSpecification)
-            val config = requireNotNull(responseSpecification.result) { "Task must be defined" }
+            val config =
+                requireNotNull(
+                    responseSpecification.result,
+                ) { "TaskPushNotificationConfig must be defined" }
             body =
                 GetTaskPushNotificationResponse(
                     id = responseSpecification.id ?: requestBody.id,

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/AgentCardTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/AgentCardTest.kt
@@ -5,10 +5,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import me.kpavlov.aimocks.a2a.model.AgentAuthentication
-import me.kpavlov.aimocks.a2a.model.AgentCapabilities
 import me.kpavlov.aimocks.a2a.model.AgentCard
-import me.kpavlov.aimocks.a2a.model.AgentProvider
 import me.kpavlov.aimocks.a2a.model.AgentSkill
 import me.kpavlov.aimocks.a2a.model.create
 import kotlin.test.Test
@@ -25,32 +22,29 @@ internal class AgentCardTest : AbstractTest() {
                     url = a2aServer.baseUrl()
                     documentationUrl = "https://example.com/documentation"
                     version = "0.0.1"
-                    provider =
-                        AgentProvider(
-                            "Acme, Inc.",
-                            "https://example.com/organization",
-                        )
-                    authentication =
-                        AgentAuthentication(
-                            schemes = listOf("none", "bearer"),
-                            credentials = "test-token",
-                        )
-                    capabilities =
-                        AgentCapabilities(
-                            streaming = true,
-                            pushNotifications = true,
-                            stateTransitionHistory = true,
-                        )
+                    provider {
+                        organization = "Acme, Inc."
+                        url = "https://example.com/organization"
+                    }
+                    authentication {
+                        schemes = listOf("none", "bearer")
+                        credentials = "test-token"
+                    }
+                    capabilities {
+                        streaming = true
+                        pushNotifications = true
+                        stateTransitionHistory = true
+                    }
                     skills =
                         listOf(
-                            AgentSkill(
-                                id = "walk",
-                                name = "Walk the walk",
-                            ),
-                            AgentSkill(
-                                id = "talk",
-                                name = "Talk the talk",
-                            ),
+                            AgentSkill.create {
+                                id = "walk"
+                                name = "Walk the walk"
+                            },
+                            AgentSkill.create {
+                                id = "talk"
+                                name = "Talk the talk"
+                            },
                         )
                 }
 

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/Clients.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/Clients.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.Json
 /**
  * Creates a Ktor `HttpClient` configured to work with Server-Sent Events (SSE).
  *
- * @param port The port number to configure the base URL for the `HttpClient`.
+ * @param url The base URL for the `HttpClient`.
  * @return A configured instance of `HttpClient` with JSON serialization, SSE support,
  *         and a default request base URL pointing to the specified port.
  */

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/GetTaskTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/GetTaskTest.kt
@@ -15,7 +15,6 @@ import me.kpavlov.aimocks.a2a.model.GetTaskRequest
 import me.kpavlov.aimocks.a2a.model.GetTaskResponse
 import me.kpavlov.aimocks.a2a.model.Task
 import me.kpavlov.aimocks.a2a.model.TaskQueryParams
-import me.kpavlov.aimocks.a2a.model.TaskStatus
 import me.kpavlov.aimocks.a2a.model.TextPart
 import java.util.UUID
 import kotlin.test.Test
@@ -34,7 +33,9 @@ internal class GetTaskTest : AbstractTest() {
                 result {
                     id = "tid_12345"
                     sessionId = null
-                    status = TaskStatus(state = "completed")
+                    status {
+                        state = "completed"
+                    }
                     artifacts =
                         listOf(
                             Artifact(

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/SendTaskStreamingTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/SendTaskStreamingTest.kt
@@ -3,11 +3,10 @@ package me.kpavlov.aimocks.a2a
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.ktor.client.plugins.sse.sse
-import io.ktor.http.ContentType
-import io.ktor.http.HttpMethod
-import io.ktor.http.content.TextContent
-import io.ktor.utils.io.InternalAPI
+import io.ktor.client.plugins.sse.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.utils.io.*
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
@@ -23,7 +22,8 @@ import me.kpavlov.aimocks.a2a.model.TaskStatus
 import me.kpavlov.aimocks.a2a.model.TaskStatusUpdateEvent
 import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
 import me.kpavlov.aimocks.a2a.model.TextPart
-import java.util.UUID
+import me.kpavlov.aimocks.a2a.model.create
+import java.util.*
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
@@ -34,6 +34,7 @@ internal class SendTaskStreamingTest : AbstractTest() {
      */
     @OptIn(InternalAPI::class)
     @Test
+    @Suppress("LongMethod")
     fun `Should send task streaming`() =
         runTest {
             val taskId: TaskId = "task_12345"
@@ -49,8 +50,8 @@ internal class SendTaskStreamingTest : AbstractTest() {
                             ),
                         )
                         emit(
-                            TaskArtifactUpdateEvent(
-                                id = taskId,
+                            TaskArtifactUpdateEvent.create {
+                                id = taskId
                                 artifact =
                                     Artifact(
                                         name = "joke",
@@ -61,12 +62,12 @@ internal class SendTaskStreamingTest : AbstractTest() {
                                                 ),
                                             ),
                                         append = false,
-                                    ),
-                            ),
+                                    )
+                            },
                         )
                         emit(
-                            TaskArtifactUpdateEvent(
-                                id = taskId,
+                            TaskArtifactUpdateEvent.create {
+                                id = taskId
                                 artifact =
                                     Artifact(
                                         name = "joke",
@@ -77,12 +78,12 @@ internal class SendTaskStreamingTest : AbstractTest() {
                                                 ),
                                             ),
                                         append = false,
-                                    ),
-                            ),
+                                    )
+                            },
                         )
                         emit(
-                            TaskArtifactUpdateEvent(
-                                id = taskId,
+                            TaskArtifactUpdateEvent.create {
+                                id = taskId
                                 artifact =
                                     Artifact(
                                         name = "joke",
@@ -93,12 +94,12 @@ internal class SendTaskStreamingTest : AbstractTest() {
                                                 ),
                                             ),
                                         append = false,
-                                    ),
-                            ),
+                                    )
+                            },
                         )
                         emit(
-                            TaskArtifactUpdateEvent(
-                                id = taskId,
+                            TaskArtifactUpdateEvent.create {
+                                id = taskId
                                 artifact =
                                     Artifact(
                                         name = "joke",
@@ -110,8 +111,8 @@ internal class SendTaskStreamingTest : AbstractTest() {
                                             ),
                                         append = false,
                                         lastChunk = true,
-                                    ),
-                            ),
+                                    )
+                            },
                         )
                         emit(
                             TaskStatusUpdateEvent(
@@ -132,8 +133,8 @@ internal class SendTaskStreamingTest : AbstractTest() {
                         SendTaskStreamingRequest(
                             id = "1",
                             params =
-                                TaskSendParams(
-                                    id = UUID.randomUUID().toString(),
+                                TaskSendParams.create {
+                                    id = UUID.randomUUID().toString()
                                     message =
                                         Message(
                                             role = Message.Role.user,
@@ -143,8 +144,8 @@ internal class SendTaskStreamingTest : AbstractTest() {
                                                         text = "Tell me a joke",
                                                     ),
                                                 ),
-                                        ),
-                                ),
+                                        )
+                                },
                         )
                     body =
                         TextContent(
@@ -156,7 +157,7 @@ internal class SendTaskStreamingTest : AbstractTest() {
                 var reading = true
                 while (reading) {
                     incoming.collect {
-                        println("Event from server:\n$it")
+                        logger.info { "Event from server:\n$it" }
                         it.data?.let {
                             val event = Json.decodeFromString<TaskUpdateEvent>(it)
                             collectedEvents.add(event)

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/SendTaskTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/SendTaskTest.kt
@@ -16,8 +16,8 @@ import me.kpavlov.aimocks.a2a.model.SendTaskRequest
 import me.kpavlov.aimocks.a2a.model.SendTaskResponse
 import me.kpavlov.aimocks.a2a.model.Task
 import me.kpavlov.aimocks.a2a.model.TaskSendParams
-import me.kpavlov.aimocks.a2a.model.TaskStatus
 import me.kpavlov.aimocks.a2a.model.TextPart
+import me.kpavlov.aimocks.a2a.model.create
 import java.util.UUID
 import kotlin.test.Test
 
@@ -26,26 +26,28 @@ internal class SendTaskTest : AbstractTest() {
      * https://github.com/google/A2A/blob/gh-pages/documentation.md#send-a-task
      */
     @Test
+    @Suppress("LongMethod")
     fun `Should send task`() =
         runTest {
             val task =
-                Task(
-                    id = "tid_12345",
-                    sessionId = null,
-                    status = TaskStatus(state = "completed"),
-                    artifacts =
+                Task.create {
+                    id("tid_12345")
+                    status {
+                        state("completed")
+                    }
+                    artifacts(
                         listOf(
-                            Artifact(
-                                name = "joke",
-                                parts =
-                                    listOf(
-                                        TextPart(
-                                            text = "This is a joke",
-                                        ),
+                            Artifact.build {
+                                name("joke")
+                                addPart(
+                                    TextPart(
+                                        text = "This is a joke",
                                     ),
-                            ),
+                                )
+                            },
                         ),
-                )
+                    )
+                }
             val reply =
                 SendTaskResponse(
                     id = 1,


### PR DESCRIPTION
# A2A: Builders


- feat(model-builders): add DSL builders for model instances
- feat(model): add builder patterns for domain models 

    Introduced builder methods for better readability and flexibility in creating domain objects like Task, AgentCard, and TaskArtifactUpdateEvent.
- fix(a2a): improve error message for null task configuration