### PR TITLE
Better dsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,10 @@ assertThat(result.bodyAsText())
 
 **AI-Mocks** is a specialized mock server implementations (e.g., mocking OpenAI API) built using Mokksy.
 
-It supports mocking following LLMs:
+It supports mocking following AI services:
 1. [OpenAI](https://platform.openai.com/docs/api-reference/) - [ai-mocks-openai](https://kpavlov.github.io/ai-mocks/docs/ai-mocks-openai/)
 2. [Anthropic](https://docs.anthropic.com/en/api) - [ai-mocks-anthropic](https://kpavlov.github.io/ai-mocks/docs/ai-mocks-anthropic/)
+3. [Agent-to-Agent (A2A) Protocol](https://github.com/google/A2A) - [ai-mocks-a2a](https://kpavlov.github.io/ai-mocks/docs/ai-mocks/a2a/)
 
 **_NB! Not all API endpoints and parameters are supported!_**
 

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AuthenticationInfo.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AuthenticationInfo.kt
@@ -20,4 +20,6 @@ public data class AuthenticationInfo(
     val schemes: List<String>,
     @SerialName("credentials")
     val credentials: String? = null,
-)
+) {
+    public companion object
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AuthenticationInfoBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AuthenticationInfoBuilder.kt
@@ -1,0 +1,58 @@
+package me.kpavlov.aimocks.a2a.model
+
+/**
+ * Builder class for creating [AuthenticationInfo] instances.
+ *
+ * This builder provides a fluent API for constructing AuthenticationInfo objects,
+ * making it easier to configure complex settings programmatically.
+ */
+public class AuthenticationInfoBuilder {
+    public var schemes: List<String> = emptyList()
+    public var credentials: String? = null
+
+    /**
+     * Sets the schemes for authentication.
+     *
+     * @param schemes The list of authentication schemes.
+     * @return This builder instance for method chaining.
+     */
+    public fun schemes(schemes: List<String>): AuthenticationInfoBuilder {
+        this.schemes = schemes
+        return this
+    }
+
+    /**
+     * Sets the credentials for authentication.
+     *
+     * @param credentials The credentials string.
+     * @return This builder instance for method chaining.
+     */
+    public fun credentials(credentials: String?): AuthenticationInfoBuilder {
+        this.credentials = credentials
+        return this
+    }
+
+    /**
+     * Builds an [AuthenticationInfo] instance with the configured parameters.
+     *
+     * @return A new [AuthenticationInfo] instance.
+     * @throws IllegalArgumentException If required parameters are missing.
+     */
+    public fun build(): AuthenticationInfo {
+        requireNotNull(schemes) { "AuthenticationInfo requires at least one scheme" }
+        return AuthenticationInfo(
+            schemes = schemes!!,
+            credentials = credentials,
+        )
+    }
+}
+
+/**
+ * Creates a new AuthenticationInfo using the DSL builder.
+ *
+ * @param init The lambda to configure the authentication info.
+ * @return A new AuthenticationInfo instance.
+ */
+public fun AuthenticationInfo.Companion.create(
+    init: AuthenticationInfoBuilder.() -> Unit,
+): AuthenticationInfo = AuthenticationInfoBuilder().apply(init).build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationConfigBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationConfigBuilder.kt
@@ -34,6 +34,10 @@ public class PushNotificationConfigBuilder {
             authentication = authentication,
         )
     }
+
+    public fun authentication(block: AuthenticationInfoBuilder.() -> Unit) {
+        authentication = AuthenticationInfoBuilder().apply(block).build()
+    }
 }
 
 /**

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SetTaskPushNotificationResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SetTaskPushNotificationResponseSpecification.kt
@@ -4,6 +4,7 @@ import me.kpavlov.aimocks.a2a.model.RequestId
 import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationRequest
 import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationResponse
 import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfig
+import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfigBuilder
 import me.kpavlov.aimocks.core.ResponseSpecification
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import kotlin.time.Duration
@@ -15,4 +16,8 @@ public class SetTaskPushNotificationResponseSpecification(
     public var delay: Duration = Duration.ZERO,
 ) : ResponseSpecification<SetTaskPushNotificationRequest, SetTaskPushNotificationResponse>(
         response = response,
-    )
+    ) {
+    public fun result(block: TaskPushNotificationConfigBuilder.() -> Unit) {
+        result = TaskPushNotificationConfigBuilder().apply(block).build()
+    }
+}

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/SetTaskPushNotificationTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/SetTaskPushNotificationTest.kt
@@ -10,12 +10,11 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import me.kpavlov.aimocks.a2a.model.AuthenticationInfo
-import me.kpavlov.aimocks.a2a.model.PushNotificationConfig
 import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationRequest
 import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationResponse
 import me.kpavlov.aimocks.a2a.model.TaskId
 import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfig
+import me.kpavlov.aimocks.a2a.model.create
 import kotlin.test.Test
 
 internal class SetTaskPushNotificationTest : AbstractTest() {
@@ -27,22 +26,31 @@ internal class SetTaskPushNotificationTest : AbstractTest() {
         runTest {
             val taskId: TaskId = "task_12345"
             val config =
-                TaskPushNotificationConfig(
-                    id = taskId,
-                    pushNotificationConfig =
-                        PushNotificationConfig(
-                            url = "https://example.com/callback",
-                            token = "abc.def.jk",
-                            authentication =
-                                AuthenticationInfo(
-                                    schemes = listOf("Bearer"),
-                                ),
-                        ),
-                )
+                TaskPushNotificationConfig.create {
+                    id = taskId
+                    pushNotificationConfig {
+                        url = "https://example.com/callback"
+                        token = "abc.def.jk"
+                        authentication {
+                            credentials = "secret"
+                            schemes += "Bearer"
+                        }
+                    }
+                }
 
             a2aServer.setTaskPushNotification() responds {
                 id = 1
-                result = config
+                result {
+                    id = taskId
+                    pushNotificationConfig {
+                        url = "https://example.com/callback"
+                        token = "abc.def.jk"
+                        authentication {
+                            credentials = "secret"
+                            schemes += "Bearer"
+                        }
+                    }
+                }
             }
 
             val response =

--- a/docs/content/docs/ai-mocks/a2a.md
+++ b/docs/content/docs/ai-mocks/a2a.md
@@ -215,8 +215,8 @@ Client call example:
 // Create a SendTaskRequest object
 val jsonRpcRequest = SendTaskRequest(
     id = "1",
-    params = TaskSendParams(
-        id = UUID.randomUUID().toString(),
+    params = TaskSendParams.create {
+        id = UUID.randomUUID().toString()
         message = Message(
             role = Message.Role.user,
             parts = listOf(
@@ -224,8 +224,8 @@ val jsonRpcRequest = SendTaskRequest(
                     text = "Tell me a joke",
                 ),
             ),
-        ),
-    ),
+        )
+    },
 )
 
 // Make a POST request to the Send Task endpoint
@@ -443,21 +443,32 @@ Mock Server configuration:
 ```kotlin
 // Create a TaskPushNotificationConfig object
 val taskId: TaskId = "task_12345"
-val config = TaskPushNotificationConfig(
-    id = taskId,
-    pushNotificationConfig = PushNotificationConfig(
-        url = "https://example.com/callback",
-        token = "abc.def.jk",
-        authentication = AuthenticationInfo(
-            schemes = listOf("Bearer"),
-        ),
-    ),
-)
+val config = TaskPushNotificationConfig.create {
+    id = taskId
+    pushNotificationConfig {
+        url = "https://example.com/callback"
+        token = "abc.def.jk"
+        authentication {
+            credentials = "secret"
+            schemes += "Bearer"
+        }
+    }
+}
 
 // Configure the mock server to respond with the config
 a2aServer.setTaskPushNotification() responds {
     id = 1
-    result = config
+    result {
+        id = taskId
+        pushNotificationConfig {
+            url = "https://example.com/callback"
+            token = "abc.def.jk"
+            authentication {
+                credentials = "secret"
+                schemes += "Bearer"
+            }
+        }
+    }
 }
 ```
 
@@ -465,16 +476,17 @@ Client call example:
 
 ```kotlin
 // Create a TaskPushNotificationConfig object
-val config = TaskPushNotificationConfig(
-    id = "task_12345",
-    pushNotificationConfig = PushNotificationConfig(
-        url = "https://example.com/callback",
-        token = "abc.def.jk",
-        authentication = AuthenticationInfo(
-            schemes = listOf("Bearer"),
-        ),
-    ),
-)
+val config = TaskPushNotificationConfig.create {
+    id = "task_12345"
+    pushNotificationConfig {
+        url = "https://example.com/callback"
+        token = "abc.def.jk"
+        authentication {
+            credentials = "secret"
+            schemes += "Bearer"
+        }
+    }
+}
 
 // Create a SetTaskPushNotificationRequest object
 val jsonRpcRequest = SetTaskPushNotificationRequest(


### PR DESCRIPTION
- feat(a2a): add builder for TaskPushNotificationConfig 

    Introduced TaskPushNotificationConfigBuilder for fluent DSL-style configuration of task push notification settings. Added support for configuring authentication details via the newly created AuthenticationInfoBuilder.

- Update docs and readme