### PR TITLE
feat(a2a): Introduce A2AClient with HTTP interaction

### DIFF
--- a/a2a-client/build.gradle.kts
+++ b/a2a-client/build.gradle.kts
@@ -1,27 +1,25 @@
 plugins {
-    kotlin("plugin.serialization") apply true
-    alias(libs.plugins.kover) apply true
     `kotlin-convention`
     `publish-convention`
+    alias(libs.plugins.kover) apply true
 }
 
 kotlin {
+
     sourceSets {
         commonMain {
             dependencies {
-                api(project(":ai-mocks-core"))
                 api(project(":ai-mocks-a2a-models"))
                 api(libs.ktor.serialization.kotlinx.json)
-                api(libs.ktor.server.content.negotiation)
-                implementation(libs.ktor.server.sse)
                 api(libs.ktor.client.core)
                 api(libs.ktor.client.logging)
                 api(libs.ktor.client.content.negotiation)
             }
         }
-
         commonTest {
             dependencies {
+                implementation(kotlin("test"))
+                api(project(":ai-mocks-a2a"))
                 implementation(libs.assertk)
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.kotlinLogging)
@@ -32,20 +30,9 @@ kotlin {
             }
         }
 
-        jvmMain {
-            dependencies {
-                implementation(libs.ktor.server.netty)
-                implementation(libs.ktor.serialization.jackson)
-            }
-        }
-
         jvmTest {
             dependencies {
-                implementation(kotlin("test"))
-                implementation(libs.assertj.core)
                 implementation(libs.ktor.client.java)
-                implementation(libs.awaitility.kotlin)
-                implementation(libs.junit.jupiter.params)
                 runtimeOnly(libs.slf4j.simple)
             }
         }

--- a/a2a-client/gradle.properties
+++ b/a2a-client/gradle.properties
@@ -1,0 +1,1 @@
+description=Agent2Agent Client

--- a/a2a-client/src/commonMain/kotlin/me/kpavlov/a2a/client/A2AClient.kt
+++ b/a2a-client/src/commonMain/kotlin/me/kpavlov/a2a/client/A2AClient.kt
@@ -1,0 +1,114 @@
+package me.kpavlov.a2a.client
+
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.flow.Flow
+import me.kpavlov.aimocks.a2a.model.AgentCard
+import me.kpavlov.aimocks.a2a.model.CancelTaskRequest
+import me.kpavlov.aimocks.a2a.model.CancelTaskResponse
+import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationResponse
+import me.kpavlov.aimocks.a2a.model.GetTaskRequest
+import me.kpavlov.aimocks.a2a.model.GetTaskResponse
+import me.kpavlov.aimocks.a2a.model.PushNotificationConfig
+import me.kpavlov.aimocks.a2a.model.SendTaskResponse
+import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationResponse
+import me.kpavlov.aimocks.a2a.model.TaskId
+import me.kpavlov.aimocks.a2a.model.TaskSendParams
+import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
+
+/**
+ * Client for interacting with an A2A (Agent-to-Agent) server.
+ *
+ * This client provides methods for all operations supported by the A2A protocol,
+ * including sending tasks, getting tasks, canceling tasks, and managing push notifications.
+ * It also supports streaming operations.
+ */
+@Suppress("TooManyFunctions")
+public interface A2AClient {
+    /**
+     * Gets the underlying HTTP client.
+     */
+    public val httpClient: HttpClient
+
+    /**
+     * Gets the agent card from the server.
+     *
+     * @return The agent card.
+     */
+    public suspend fun getAgentCard(): AgentCard
+
+    /**
+     * Sends a task to the server.
+     *
+     * @param params The parameters for sending the task.
+     * @return The response containing the task.
+     */
+    public suspend fun sendTask(params: TaskSendParams): SendTaskResponse
+
+    /**
+     * Gets a task from the server.
+     *
+     * @param id The ID of the task to get.
+     * @param historyLength The number of history items to include (optional).
+     * @return The response containing the task.
+     */
+    public suspend fun getTask(id: TaskId, historyLength: Int? = null): GetTaskResponse
+
+    public suspend fun getTask(request: GetTaskRequest): GetTaskResponse
+
+    /**
+     * Cancels a task on the server.
+     *
+     * @param id The ID of the task to cancel.
+     * @return The response containing the canceled task.
+     */
+    public suspend fun cancelTask(id: TaskId): CancelTaskResponse
+
+    /**
+     * Cancels a task on the server.
+     *
+     * @param request [CancelTaskRequest]
+     * @return The response containing the canceled task.
+     */
+    public suspend fun cancelTask(request: CancelTaskRequest): CancelTaskResponse
+
+    /**
+     * Sets push notification configuration for a task.
+     *
+     * @param id The ID of the task.
+     * @param config The push notification configuration.
+     * @return The response containing the push notification configuration.
+     */
+    public suspend fun setTaskPushNotification(
+        id: TaskId,
+        config: PushNotificationConfig
+    ): SetTaskPushNotificationResponse
+
+    /**
+     * Gets the push notification configuration for a task.
+     *
+     * @param id The ID of the task.
+     * @return The response containing the push notification configuration.
+     */
+    public suspend fun getTaskPushNotification(id: TaskId): GetTaskPushNotificationResponse
+
+    /**
+     * Sends a task to the server and subscribes to streaming updates.
+     *
+     * @param params The parameters for sending the task.
+     * @return A flow of task update events.
+     */
+    public fun sendTaskStreaming(params: TaskSendParams): Flow<TaskUpdateEvent>
+
+    /**
+     * Resubscribes to streaming updates for a task.
+     *
+     * @param id The ID of the task.
+     * @return A flow of task update events.
+     */
+    public fun resubscribeToTask(id: TaskId): Flow<TaskUpdateEvent>
+
+    /**
+     * Closes the client and releases resources.
+     */
+    public fun close()
+}

--- a/a2a-client/src/commonMain/kotlin/me/kpavlov/a2a/client/A2AClientFactory.kt
+++ b/a2a-client/src/commonMain/kotlin/me/kpavlov/a2a/client/A2AClientFactory.kt
@@ -1,0 +1,60 @@
+package me.kpavlov.a2a.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.logging.DEFAULT
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.sse.SSE
+import io.ktor.http.HttpHeaders
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+/**
+ * Factory for creating instances of the A2AClient.
+ */
+public object A2AClientFactory {
+    /**
+     * Creates a new instance of the A2AClient.
+     *
+     * @param baseUrl The base URL of the A2A server.
+     * @param httpClient An optional HttpClient to use. If not provided, a new one will be created.
+     * @param json An optional Json serializer/deserializer to use. If not provided, a new one will be created.
+     * @return A new instance of the A2AClient.
+     */
+    public fun create(
+        baseUrl: String,
+        httpClient: HttpClient? = null,
+        json: Json = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+            prettyPrint = true
+        }
+    ): A2AClient {
+        val client = httpClient ?: HttpClient {
+            install(ContentNegotiation) {
+                json(json)
+            }
+            install(SSE) {
+                // Configure SSE client
+            }
+            install(Logging) {
+                logger = Logger.DEFAULT
+                level = LogLevel.ALL
+                sanitizeHeader { header -> header == HttpHeaders.Authorization }
+            }
+            defaultRequest {
+                url(baseUrl)
+                headers.append(HttpHeaders.UserAgent, "mokksy-a2a-client")
+            }
+        }
+
+        return DefaultA2AClient(
+            httpClient = client,
+            baseUrl = baseUrl,
+            json = json
+        )
+    }
+}

--- a/a2a-client/src/commonMain/kotlin/me/kpavlov/a2a/client/DefaultA2AClient.kt
+++ b/a2a-client/src/commonMain/kotlin/me/kpavlov/a2a/client/DefaultA2AClient.kt
@@ -1,0 +1,275 @@
+package me.kpavlov.a2a.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.sse.sse
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import io.ktor.http.content.TextContent
+import io.ktor.http.contentType
+import io.ktor.utils.io.InternalAPI
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.serialization.json.Json
+import me.kpavlov.aimocks.a2a.model.AgentCard
+import me.kpavlov.aimocks.a2a.model.CancelTaskRequest
+import me.kpavlov.aimocks.a2a.model.CancelTaskResponse
+import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationRequest
+import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationResponse
+import me.kpavlov.aimocks.a2a.model.GetTaskRequest
+import me.kpavlov.aimocks.a2a.model.GetTaskResponse
+import me.kpavlov.aimocks.a2a.model.PushNotificationConfig
+import me.kpavlov.aimocks.a2a.model.SendTaskRequest
+import me.kpavlov.aimocks.a2a.model.SendTaskResponse
+import me.kpavlov.aimocks.a2a.model.SendTaskStreamingRequest
+import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationRequest
+import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationResponse
+import me.kpavlov.aimocks.a2a.model.TaskId
+import me.kpavlov.aimocks.a2a.model.TaskIdParams
+import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfig
+import me.kpavlov.aimocks.a2a.model.TaskQueryParams
+import me.kpavlov.aimocks.a2a.model.TaskSendParams
+import me.kpavlov.aimocks.a2a.model.TaskStatusUpdateEvent
+import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
+import java.util.UUID
+
+/**
+ * Default implementation of the A2AClient interface.
+ *
+ * @property httpClient The Ktor HTTP client used for making requests.
+ * @property baseUrl The base URL of the A2A server.
+ * @property json The JSON serializer/deserializer.
+ */
+@Suppress("TooManyFunctions")
+public class DefaultA2AClient(
+    override val httpClient: HttpClient,
+    private val baseUrl: String,
+    private val json: Json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+) : A2AClient {
+
+    /**
+     * Gets the agent card from the server.
+     *
+     * @return The agent card.
+     */
+    override suspend fun getAgentCard(): AgentCard {
+        val response = httpClient.get("$baseUrl/.well-known/agent.json")
+        return response.body<AgentCard>()
+    }
+
+    /**
+     * Sends a task to the server.
+     *
+     * @param params The parameters for sending the task.
+     * @return The response containing the task.
+     */
+    override suspend fun sendTask(params: TaskSendParams): SendTaskResponse {
+        val request = SendTaskRequest.create {
+            id = "1"
+            this.params = params
+        }
+
+        val response = httpClient.post(baseUrl) {
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(SendTaskRequest.serializer(), request))
+        }
+
+        return response.body<String>().let { json.decodeFromString<SendTaskResponse>(it) }
+    }
+
+    /**
+     * Gets a task from the server.
+     *
+     * @param id The ID of the task to get.
+     * @param historyLength The number of history items to include (optional).
+     * @return The response containing the task.
+     */
+    override suspend fun getTask(id: TaskId, historyLength: Int?): GetTaskResponse {
+        val request = GetTaskRequest(
+            id = "1",
+            params = TaskQueryParams(
+                id = id,
+                historyLength = historyLength?.toLong()
+            )
+        )
+        return getTask(request)
+    }
+
+    override suspend fun getTask(request: GetTaskRequest): GetTaskResponse {
+        val response = httpClient.post(baseUrl) {
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }
+
+        return response.body<GetTaskResponse>()
+    }
+
+    /**
+     * Cancels a task on the server.
+     *
+     * @param id The ID of the task to cancel.
+     * @return The response containing the canceled task.
+     */
+    override suspend fun cancelTask(id: TaskId): CancelTaskResponse {
+        val request = CancelTaskRequest(
+            id = UUID.randomUUID().toString(),
+            params = TaskIdParams(
+                id = id
+            )
+        )
+        return cancelTask(request)
+    }
+
+
+    override suspend fun cancelTask(request: CancelTaskRequest): CancelTaskResponse {
+        val response = httpClient.post(baseUrl) {
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }
+
+        return response.body<CancelTaskResponse>()
+    }
+
+    /**
+     * Sets push notification configuration for a task.
+     *
+     * @param id The ID of the task.
+     * @param config The push notification configuration.
+     * @return The response containing the push notification configuration.
+     */
+    override suspend fun setTaskPushNotification(
+        id: TaskId,
+        config: PushNotificationConfig
+    ): SetTaskPushNotificationResponse {
+        val request = SetTaskPushNotificationRequest(
+            id = "1",
+            params = TaskPushNotificationConfig(
+                id = id,
+                pushNotificationConfig = config
+            )
+        )
+
+        val response = httpClient.post(baseUrl) {
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(SetTaskPushNotificationRequest.serializer(), request))
+        }
+
+        return response.body<String>().let { json.decodeFromString<SetTaskPushNotificationResponse>(it) }
+    }
+
+    /**
+     * Gets the push notification configuration for a task.
+     *
+     * @param id The ID of the task.
+     * @return The response containing the push notification configuration.
+     */
+    override suspend fun getTaskPushNotification(id: TaskId): GetTaskPushNotificationResponse {
+        val request = GetTaskPushNotificationRequest(
+            id = "1",
+            params = TaskIdParams(
+                id = id
+            )
+        )
+
+        val response = httpClient.post(baseUrl) {
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(GetTaskPushNotificationRequest.serializer(), request))
+        }
+
+        return response.body<String>().let { json.decodeFromString<GetTaskPushNotificationResponse>(it) }
+    }
+
+    /**
+     * Sends a task to the server and subscribes to streaming updates.
+     *
+     * @param params The parameters for sending the task.
+     * @return A flow of task update events.
+     */
+    @OptIn(InternalAPI::class)
+    override fun sendTaskStreaming(params: TaskSendParams): Flow<TaskUpdateEvent> {
+        val payload = SendTaskStreamingRequest(
+            id = "1",
+            params = params
+        )
+
+        return flow {
+            httpClient.sse(
+                request = {
+                    url { baseUrl }
+                    method = HttpMethod.Post
+                    body = TextContent(
+                        text = json.encodeToString(SendTaskStreamingRequest.serializer(), payload),
+                        contentType = ContentType.Application.Json
+                    )
+                }
+            ) {
+                var reading = true
+                while (reading) {
+                    incoming.collect { event ->
+                        event.data?.let { data ->
+                            val taskEvent = json.decodeFromString<TaskUpdateEvent>(data)
+                            emit(taskEvent)
+
+                            // Check if this is the final event
+                            if (taskEvent is me.kpavlov.aimocks.a2a.model.TaskStatusUpdateEvent && taskEvent.final) {
+                                reading = false
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Resubscribes to streaming updates for a task.
+     *
+     * @param id The ID of the task.
+     * @return A flow of task update events.
+     */
+    @OptIn(InternalAPI::class)
+    override fun resubscribeToTask(id: TaskId): Flow<TaskUpdateEvent> {
+        val payload = """{"jsonrpc":"2.0","id":1,"method":"tasks/resubscribe","params":{"id":"$id"}}"""
+
+        return flow {
+            httpClient.sse(
+                request = {
+                    url { baseUrl }
+                    method = HttpMethod.Post
+                    body = TextContent(
+                        text = payload,
+                        contentType = ContentType.Application.Json
+                    )
+                }
+            ) {
+                var reading = true
+                while (reading) {
+                    incoming.collect { event ->
+                        event.data?.let { data ->
+                            val taskEvent = json.decodeFromString<TaskUpdateEvent>(data)
+                            emit(taskEvent)
+
+                            // Check if this is the final event
+                            if (taskEvent is TaskStatusUpdateEvent && taskEvent.final) {
+                                reading = false
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Closes the client and releases resources.
+     */
+    override fun close() {
+        httpClient.close()
+    }
+}

--- a/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/AbstractTest.kt
+++ b/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/AbstractTest.kt
@@ -1,0 +1,19 @@
+package me.kpavlov.a2a.client
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import me.kpavlov.aimocks.a2a.MockAgentServer
+import org.junit.jupiter.api.AfterEach
+
+internal abstract class AbstractTest {
+    protected val logger = KotlinLogging.logger(name = javaClass.canonicalName!!)
+    protected val a2aServer = MockAgentServer(verbose = true)
+
+    @Deprecated("Use client instead")
+    protected val a2aClient = createA2AClient(url = a2aServer.baseUrl())
+    protected val client = A2AClientFactory.create(baseUrl = a2aServer.baseUrl())
+
+    @AfterEach
+    fun afterEach() {
+        a2aServer.verifyNoUnmatchedRequests()
+    }
+}

--- a/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/AgentCardTest.kt
+++ b/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/AgentCardTest.kt
@@ -1,0 +1,56 @@
+package me.kpavlov.a2a.client
+
+import io.kotest.matchers.equals.shouldBeEqual
+import kotlinx.coroutines.test.runTest
+import me.kpavlov.aimocks.a2a.model.AgentCard
+import me.kpavlov.aimocks.a2a.model.create
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+
+internal class AgentCardTest : AbstractTest() {
+    @Test
+    fun `Should get AgentCard`() =
+        runTest {
+            val agentCard =
+                AgentCard.create {
+                    name = "test-agent"
+                    description = "test-agent-description"
+                    url = a2aServer.baseUrl()
+                    documentationUrl = "https://example.com/documentation"
+                    version = "0.0.1"
+                    provider {
+                        organization = "Acme, Inc."
+                        url = "https://example.com/organization"
+                    }
+                    authentication {
+                        schemes = listOf("none", "bearer")
+                        credentials = "test-token"
+                    }
+                    capabilities {
+                        streaming = true
+                        pushNotifications = true
+                        stateTransitionHistory = true
+                    }
+                    skills +=
+                        skill {
+                            id = "walk"
+                            name = "Walk the walk"
+                        }
+                    skills +=
+                        skill {
+                            id = "talk"
+                            name = "Talk the talk"
+                        }
+                }
+
+            a2aServer.agentCard() responds {
+                delay = 1.milliseconds
+                card = agentCard
+            }
+
+            val receivedCard =
+                client.getAgentCard()
+
+            receivedCard shouldBeEqual agentCard
+        }
+}

--- a/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/CancelTaskTest.kt
+++ b/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/CancelTaskTest.kt
@@ -1,0 +1,48 @@
+package me.kpavlov.a2a.client
+
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import kotlinx.coroutines.test.runTest
+import me.kpavlov.aimocks.a2a.model.CancelTaskResponse
+import me.kpavlov.aimocks.a2a.model.Task
+import me.kpavlov.aimocks.a2a.model.TaskStatus
+import me.kpavlov.aimocks.a2a.model.cancelTaskRequest
+import java.util.UUID
+import kotlin.test.Test
+
+internal class CancelTaskTest : AbstractTest() {
+    /**
+     * https://github.com/google/A2A/blob/gh-pages/documentation.md#send-a-task
+     */
+    @Test
+    fun `Should cancel task`() =
+        runTest {
+            lateinit var expectedTask: Task
+
+            a2aServer.cancelTask() responds {
+                id = 1
+                result {
+                    id = "tid_12345"
+                    sessionId = UUID.randomUUID().toString()
+                    status = TaskStatus(state = "canceled")
+                }
+                expectedTask = requireNotNull(result) { "Result should not be null" }
+            }
+
+            val jsonRpcRequest =
+                cancelTaskRequest {
+                    id = "1"
+                    params {
+                        id = UUID.randomUUID().toString()
+                    }
+                }
+
+            val payload = client.cancelTask(jsonRpcRequest)
+
+            val expectedReply =
+                CancelTaskResponse(
+                    id = 1,
+                    result = expectedTask,
+                )
+            payload shouldBeEqualToComparingFields expectedReply
+        }
+}

--- a/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/Clients.kt
+++ b/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/Clients.kt
@@ -1,0 +1,33 @@
+package me.kpavlov.a2a.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.java.Java
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.sse.SSE
+import kotlinx.serialization.json.Json
+
+/**
+ * Creates a Ktor `HttpClient` configured to work with Server-Sent Events (SSE).
+ *
+ * @param url The base URL for the `HttpClient`.
+ * @return A configured instance of `HttpClient` with JSON serialization, SSE support,
+ *         and a default request base URL pointing to the specified port.
+ */
+@Deprecated("Use A2AClientFactory.create() instead")
+internal fun createA2AClient(url: String): HttpClient =
+    HttpClient(Java) {
+        install(ContentNegotiation) {
+            Json {
+                prettyPrint = true
+                isLenient = true
+            }
+        }
+        install(SSE) {
+            showRetryEvents()
+            showCommentEvents()
+        }
+        install(DefaultRequest) {
+            url(url) // Set the base URL
+        }
+    }

--- a/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/GetTaskPushNotificationTest.kt
+++ b/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/GetTaskPushNotificationTest.kt
@@ -1,0 +1,47 @@
+package me.kpavlov.a2a.client
+
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import kotlinx.coroutines.test.runTest
+import me.kpavlov.aimocks.a2a.model.AuthenticationInfo
+import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationResponse
+import me.kpavlov.aimocks.a2a.model.PushNotificationConfig
+import me.kpavlov.aimocks.a2a.model.TaskId
+import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfig
+import kotlin.test.Test
+
+internal class GetTaskPushNotificationTest : AbstractTest() {
+    /**
+     * https://github.com/google/A2A/blob/gh-pages/documentation.md#send-a-task
+     */
+    @Test
+    fun `Should get TaskPushNotification config`() =
+        runTest {
+            val taskId: TaskId = "task_12345"
+            val config =
+                TaskPushNotificationConfig(
+                    id = taskId,
+                    pushNotificationConfig =
+                        PushNotificationConfig(
+                            url = "https://example.com/callback",
+                            token = "abc.def.jk",
+                            authentication =
+                                AuthenticationInfo(
+                                    schemes = listOf("Bearer"),
+                                ),
+                        ),
+                )
+
+            a2aServer.getTaskPushNotification() responds {
+                id = 1
+                result = config
+            }
+
+            val payload = client.getTaskPushNotification(taskId)
+            logger.info { "response = $payload" }
+            payload shouldBeEqualToComparingFields
+                GetTaskPushNotificationResponse(
+                    id = 1,
+                    result = config,
+                )
+        }
+}

--- a/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/GetTaskTest.kt
+++ b/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/GetTaskTest.kt
@@ -1,0 +1,60 @@
+package me.kpavlov.a2a.client
+
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import kotlinx.coroutines.test.runTest
+import me.kpavlov.aimocks.a2a.model.GetTaskRequest
+import me.kpavlov.aimocks.a2a.model.GetTaskResponse
+import me.kpavlov.aimocks.a2a.model.Task
+import me.kpavlov.aimocks.a2a.model.TaskQueryParams
+import java.util.UUID
+import kotlin.test.Test
+
+internal class GetTaskTest : AbstractTest() {
+    /**
+     * https://github.com/google/A2A/blob/gh-pages/documentation.md#send-a-task
+     */
+    @Test
+    fun `Should get task`() =
+        runTest {
+            lateinit var expectedTask: Task
+
+            a2aServer.getTask() responds {
+                id = 1
+                result {
+                    id = "tid_12345"
+                    sessionId = null
+                    status {
+                        state = "completed"
+                    }
+                    artifacts +=
+                        artifact {
+                            name = "joke"
+                            parts +=
+                                textPart {
+                                    text = "This is a joke"
+                                }
+                        }
+                }
+                expectedTask = requireNotNull(result) { "Result should not be null" }
+            }
+
+            val response =
+                client.getTask(
+                    GetTaskRequest(
+                        id = "1",
+                        params =
+                            TaskQueryParams(
+                                id = UUID.randomUUID().toString(),
+                                historyLength = 2,
+                            ),
+                    )
+                )
+
+            val expectedReply =
+                GetTaskResponse(
+                    id = 1,
+                    result = expectedTask,
+                )
+            response shouldBeEqualToComparingFields expectedReply
+        }
+}

--- a/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/SendTaskStreamingTest.kt
+++ b/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/SendTaskStreamingTest.kt
@@ -1,0 +1,172 @@
+package me.kpavlov.a2a.client
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.ktor.utils.io.InternalAPI
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock.System
+import me.kpavlov.aimocks.a2a.model.Message
+import me.kpavlov.aimocks.a2a.model.TaskArtifactUpdateEvent
+import me.kpavlov.aimocks.a2a.model.TaskId
+import me.kpavlov.aimocks.a2a.model.TaskSendParams
+import me.kpavlov.aimocks.a2a.model.TaskStatusUpdateEvent
+import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
+import me.kpavlov.aimocks.a2a.model.TextPart
+import me.kpavlov.aimocks.a2a.model.create
+import me.kpavlov.aimocks.a2a.model.taskArtifactUpdateEvent
+import me.kpavlov.aimocks.a2a.model.taskStatusUpdateEvent
+import java.util.UUID
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+
+internal class SendTaskStreamingTest : AbstractTest() {
+    /**
+     * https://github.com/google/A2A/blob/gh-pages/documentation.md#send-a-task
+     */
+    @OptIn(InternalAPI::class)
+    @Test
+    @Suppress("LongMethod")
+    fun `Should send task streaming`() =
+        runTest {
+            val taskId: TaskId = "task_12345"
+
+            a2aServer.sendTaskStreaming() responds {
+                delayBetweenChunks = 1.seconds
+                responseFlow =
+                    flow {
+                        emit(
+                            taskStatusUpdateEvent {
+                                id = taskId
+                                status {
+                                    state = "working"
+                                    timestamp = System.now()
+                                }
+                            },
+                        )
+                        emit(
+                            taskArtifactUpdateEvent {
+                                id = taskId
+                                artifact {
+                                    name = "joke"
+                                    parts +=
+                                        textPart {
+                                            text = "This"
+                                        }
+                                }
+                            },
+                        )
+                        emit(
+                            taskArtifactUpdateEvent {
+                                id = taskId
+                                artifact {
+                                    name = "joke"
+                                    parts +=
+                                        textPart {
+                                            text = "is"
+                                        }
+                                    append = true
+                                }
+                            },
+                        )
+                        emit(
+                            taskArtifactUpdateEvent {
+                                id = taskId
+                                artifact {
+                                    name = "joke"
+                                    parts +=
+                                        textPart {
+                                            text = "a"
+                                        }
+                                    append = true
+                                }
+                            },
+                        )
+                        emit(
+                            taskArtifactUpdateEvent {
+                                id = taskId
+                                artifact {
+                                    name = "joke"
+                                    parts +=
+                                        textPart {
+                                            text = "joke!"
+                                        }
+                                    append = true
+                                    lastChunk = true
+                                }
+                            },
+                        )
+                        emit(
+                            taskStatusUpdateEvent {
+                                id = taskId
+                                status {
+                                    state = "completed"
+                                    timestamp = System.now()
+                                }
+                                final = true
+                            },
+                        )
+                    }
+            }
+
+            val taskParams = TaskSendParams.create {
+                id = UUID.randomUUID().toString()
+                message {
+                    role = Message.Role.user
+                    parts +=
+                        textPart {
+                            text = "Tell me a joke"
+                        }
+                }
+            }
+
+            val collectedEvents = ConcurrentLinkedQueue<TaskUpdateEvent>()
+            client.sendTaskStreaming(taskParams).collect { event ->
+                logger.info { "Event from server: $event" }
+                collectedEvents.add(event)
+                handleEvent(event)
+            }
+
+            collectedEvents shouldHaveSize 6
+            collectedEvents.forEach {
+                it.id() shouldBe taskId
+            }
+            (collectedEvents.first() as TaskStatusUpdateEvent).let {
+                it.status.state shouldBe "working"
+                it.status.timestamp.shouldNotBeNull()
+            }
+            (collectedEvents.last() as TaskStatusUpdateEvent).let {
+                it.final shouldBe true
+                it.status.state shouldBe "completed"
+                it.status.timestamp.shouldNotBeNull()
+            }
+            val joke =
+                collectedEvents
+                    .filter { it is TaskArtifactUpdateEvent }
+                    .map { it as TaskArtifactUpdateEvent }
+                    .filter { it.artifact.name == "joke" }
+                    .map { it.artifact.parts[0] as TextPart }
+                    .map { it.text }
+                    .toList()
+                    .joinToString(separator = " ")
+            joke shouldBe "This is a joke!"
+        }
+
+    private fun handleEvent(event: TaskUpdateEvent): Boolean {
+        when (event) {
+            is TaskStatusUpdateEvent -> {
+                logger.info { "Task status: $event" }
+                if (event.final) {
+                    return false
+                }
+            }
+
+            is TaskArtifactUpdateEvent -> {
+                logger.info { "Task artifact: $event" }
+            }
+        }
+        return true
+    }
+}

--- a/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/SendTaskTest.kt
+++ b/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/SendTaskTest.kt
@@ -1,0 +1,62 @@
+package me.kpavlov.a2a.client
+
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import kotlinx.coroutines.test.runTest
+import me.kpavlov.aimocks.a2a.model.Message
+import me.kpavlov.aimocks.a2a.model.SendTaskResponse
+import me.kpavlov.aimocks.a2a.model.Task
+import me.kpavlov.aimocks.a2a.model.create
+import java.util.UUID
+import kotlin.test.Test
+
+internal class SendTaskTest : AbstractTest() {
+    /**
+     * https://github.com/google/A2A/blob/gh-pages/documentation.md#send-a-task
+     */
+    @Test
+    @Suppress("LongMethod")
+    fun `Should send task`() =
+        runTest {
+            val task =
+                Task.create {
+                    id = "tid_12345"
+                    status {
+                        state = "completed"
+                    }
+                    artifacts +=
+                        artifact {
+                            name = "joke"
+                            parts +=
+                                textPart {
+                                    text = "This is a joke"
+                                }
+                        }
+                }
+
+            val reply =
+                SendTaskResponse(
+                    id = 1,
+                    result = task,
+                )
+
+            a2aServer.sendTask() responds {
+                id = 1
+                result = task
+            }
+
+            val taskParams = me.kpavlov.aimocks.a2a.model.TaskSendParams.create {
+                id = UUID.randomUUID().toString()
+                message {
+                    role = Message.Role.user
+                    parts +=
+                        textPart {
+                            text = "Tell me a joke"
+                        }
+                }
+            }
+
+            val payload = client.sendTask(taskParams)
+            logger.info { "response = $payload" }
+            payload shouldBeEqualToComparingFields reply
+        }
+}

--- a/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/SetTaskPushNotificationTest.kt
+++ b/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/SetTaskPushNotificationTest.kt
@@ -1,0 +1,58 @@
+package me.kpavlov.a2a.client
+
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import kotlinx.coroutines.test.runTest
+import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationResponse
+import me.kpavlov.aimocks.a2a.model.TaskId
+import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfig
+import me.kpavlov.aimocks.a2a.model.create
+import kotlin.test.Test
+
+internal class SetTaskPushNotificationTest : AbstractTest() {
+    /**
+     * https://github.com/google/A2A/blob/gh-pages/documentation.md#send-a-task
+     */
+    @Test
+    fun `Should set TaskPushNotification config`() =
+        runTest {
+            val taskId: TaskId = "task_12345"
+            val config =
+                TaskPushNotificationConfig.create {
+                    id = taskId
+                    pushNotificationConfig {
+                        url = "https://example.com/callback"
+                        token = "abc.def.jk"
+                        authentication {
+                            credentials = "secret"
+                            schemes += "Bearer"
+                        }
+                    }
+                }
+
+            a2aServer.setTaskPushNotification() responds {
+                id = 1
+                result {
+                    id = taskId
+                    pushNotificationConfig {
+                        url = "https://example.com/callback"
+                        token = "abc.def.jk"
+                        authentication {
+                            credentials = "secret"
+                            schemes += "Bearer"
+                        }
+                    }
+                }
+            }
+
+            val payload = client.setTaskPushNotification(
+                id = taskId,
+                config = config.pushNotificationConfig
+            )
+            logger.info { "response = $payload" }
+            payload shouldBeEqualToComparingFields
+                SetTaskPushNotificationResponse(
+                    id = 1,
+                    result = config,
+                )
+        }
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
@@ -82,7 +82,7 @@ public open class MockAgentServer(
         name: String? = null,
     ): AbstractBuildingStep<Nothing, AgentCardResponseSpecification> {
         val requestStep =
-            mokksy.get<Nothing>(
+            mokksy.get(
                 name = name,
                 requestType = Nothing::class,
             ) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ subprojects {
 }
 
 dependencies {
+    kover(project(":a2a-client"))
     kover(project(":ai-mocks-a2a"))
     kover(project(":ai-mocks-a2a-models"))
     kover(project(":ai-mocks-anthropic"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-java = { module = "io.ktor:ktor-client-java", version.ref = "ktor" }
+ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-serialization-jackson = { module = "io.ktor:ktor-serialization-jackson", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-call-logging = { module = "io.ktor:ktor-server-call-logging", version.ref = "ktor" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,11 @@
 rootProject.name = "ai-mocks"
 
 include(
-    ":mokksy",
-    ":ai-mocks-a2a-models",
+    ":a2a-client",
     ":ai-mocks-a2a",
+    ":ai-mocks-a2a-models",
+    ":ai-mocks-anthropic",
     ":ai-mocks-core",
     ":ai-mocks-openai",
-    ":ai-mocks-anthropic",
+    ":mokksy",
 )


### PR DESCRIPTION
Added a new A2AClient interface and its implementation for interacting with the Agent-to-Agent (A2A) server.
Includes functionality for task management, streaming, and HTTP client interactions.
Updated test cases and dependencies to utilize the new client abstraction.