### PR TITLE
Add default config and enhance A2AClient documentation

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,8 +39,7 @@ jobs:
         with:
           gradle-version: 8.13
           add-job-summary-as-pr-comment: on-failure # Valid values are 'never' (default), 'always', and 'on-failure'
-          # cache-cleanup: 'always'
-          cache-disabled: 'true'
+          cache-cleanup: 'always'
 
       - name: Build with Gradle
         run: gradle --no-daemon clean build dokkaGenerate koverXmlReport

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,7 +41,7 @@ jobs:
           add-job-summary-as-pr-comment: on-failure # Valid values are 'never' (default), 'always', and 'on-failure'
 
       - name: Build with Gradle
-        run: gradle --no-daemon build dokkaGenerate koverXmlReport
+        run: gradle --no-daemon clean build dokkaGenerate koverXmlReport
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           gradle-version: 8.13
           add-job-summary-as-pr-comment: on-failure # Valid values are 'never' (default), 'always', and 'on-failure'
+          # cache-cleanup: 'always'
+          cache-disabled: 'true'
 
       - name: Build with Gradle
         run: gradle --no-daemon clean build dokkaGenerate koverXmlReport

--- a/a2a-client/build.gradle.kts
+++ b/a2a-client/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
                 implementation(libs.ktor.client.java)
                 implementation(libs.kotlinx.coroutines.core.jvm)
                 implementation(libs.assertj.core)
-                implementation(libs.awaitility.kotlin)
+                implementation(libs.awaitility)
                 runtimeOnly(libs.slf4j.simple)
             }
         }

--- a/a2a-client/src/commonMain/kotlin/me/kpavlov/a2a/client/A2AClient.kt
+++ b/a2a-client/src/commonMain/kotlin/me/kpavlov/a2a/client/A2AClient.kt
@@ -24,7 +24,11 @@ import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
  *
  * This client provides methods for all operations supported by the A2A protocol,
  * including sending tasks, getting tasks, canceling tasks, and managing push notifications.
- * It also supports streaming operations.
+ * It also supports streaming operations for real-time task updates.
+ *
+ * The A2A protocol enables communication between AI agents, allowing them to work
+ * together on complex tasks. This client implementation handles the HTTP communication
+ * details and data serialization/deserialization required by the protocol.
  */
 @Suppress("TooManyFunctions")
 public interface A2AClient {
@@ -36,94 +40,173 @@ public interface A2AClient {
     /**
      * Gets the agent card from the server.
      *
-     * @return The agent card.
+     * Agent cards provide metadata about an agent, including its capabilities,
+     * identity, and other relevant information according to the A2A protocol.
+     * This metadata helps other agents understand how to interact with this agent.
+     *
+     * @return The agent card containing agent metadata.
      */
     public suspend fun getAgentCard(): AgentCard
 
     /**
      * Sends a task to the server.
      *
-     * @param params The parameters for sending the task.
-     * @return The response containing the task.
+     * This method creates a new task on the A2A server with the specified parameters.
+     * Tasks represent work items that agents can process asynchronously.
+     *
+     * @param params The parameters for sending the task, including input data and requirements.
+     * @return The response containing the created task with assigned ID and initial status.
      */
     public suspend fun sendTask(params: TaskSendParams): SendTaskResponse
 
+    /**
+     * Sends a task to the server using a pre-constructed request object.
+     *
+     * This method allows for more control over the request, including setting a custom
+     * request ID and complete request parameters.
+     *
+     * @param request The fully constructed task request containing ID and parameters.
+     * @return The response containing the created task with assigned ID and initial status.
+     */
     public suspend fun sendTask(request: SendTaskRequest): SendTaskResponse
 
     /**
      * Gets a task from the server.
      *
+     * Retrieves a task by its ID, optionally including a specified number of
+     * history items to show the task's progression over time.
+     *
      * @param id The ID of the task to get.
      * @param historyLength The number of history items to include (optional).
-     * @return The response containing the task.
+     * @return The response containing the task details, status, and history if requested.
      */
     public suspend fun getTask(
         id: TaskId,
         historyLength: Int? = null,
     ): GetTaskResponse
 
+    /**
+     * Gets a task from the server using a pre-constructed request object.
+     *
+     * This method allows for more control over the request, including setting a custom
+     * request ID and complete query parameters.
+     *
+     * @param request The fully constructed task request containing ID and query parameters.
+     * @return The response containing the task details, status, and history if requested.
+     */
     public suspend fun getTask(request: GetTaskRequest): GetTaskResponse
 
     /**
      * Cancels a task on the server.
      *
+     * Sends a request to stop processing a task. Depending on the server implementation,
+     * a canceled task might be immediately terminated or gracefully completed.
+     *
      * @param id The ID of the task to cancel.
-     * @return The response containing the canceled task.
+     * @return The response containing the canceled task with the updated status.
      */
     public suspend fun cancelTask(id: TaskId): CancelTaskResponse
 
     /**
-     * Cancels a task on the server.
+     * Cancels a task on the server using a pre-constructed request object.
      *
-     * @param request [CancelTaskRequest]
-     * @return The response containing the canceled task.
+     * This method allows for more control over the request, including setting a custom
+     * request ID and complete cancellation parameters.
+     *
+     * @param request The fully constructed cancellation request containing request ID and task parameters.
+     * @return The response containing the canceled task with the updated status.
      */
     public suspend fun cancelTask(request: CancelTaskRequest): CancelTaskResponse
 
     /**
      * Sets push notification configuration for a task.
      *
+     * Configures how notifications about task status changes should be delivered.
+     * This allows clients to receive updates about task progress without polling.
+     *
      * @param id The ID of the task.
-     * @param config The push notification configuration.
-     * @return The response containing the push notification configuration.
+     * @param config The push notification configuration containing delivery settings.
+     * @return The response containing the updated push notification configuration.
      */
     public suspend fun setTaskPushNotification(
         id: TaskId,
         config: PushNotificationConfig,
     ): SetTaskPushNotificationResponse
 
+    /**
+     * Sets push notification configuration for a task using a pre-constructed request object.
+     *
+     * This method allows for more control over the request, including setting a custom
+     * request ID and complete notification parameters.
+     *
+     * @param request The fully constructed request containing ID, task ID, and notification configuration.
+     * @return The response containing the updated push notification configuration.
+     */
     public suspend fun setTaskPushNotification(request: SetTaskPushNotificationRequest): SetTaskPushNotificationResponse
 
     /**
      * Gets the push notification configuration for a task.
      *
+     * Retrieves the current settings for how notifications about task status changes
+     * are delivered for the specified task.
+     *
      * @param id The ID of the task.
-     * @return The response containing the push notification configuration.
+     * @return The response containing the current push notification configuration.
      */
     public suspend fun getTaskPushNotification(id: TaskId): GetTaskPushNotificationResponse
 
+    /**
+     * Gets the push notification configuration for a task using a pre-constructed request object.
+     *
+     * This overload allows for more control over the request, including setting a custom
+     * request ID and complete query parameters.
+     *
+     * @param request The fully constructed request containing request ID and task parameters.
+     * @return The response containing the current push notification configuration.
+     */
     public suspend fun getTaskPushNotification(request: GetTaskPushNotificationRequest): GetTaskPushNotificationResponse
 
     /**
      * Sends a task to the server and subscribes to streaming updates.
      *
-     * @param params The parameters for sending the task.
-     * @return A flow of task update events.
+     * This method creates a new task and establishes a streaming connection that provides
+     * real-time updates about the task's progress. The connection uses Server-Sent Events (SSE)
+     * to deliver updates as they occur without requiring polling.
+     *
+     * @param params The parameters for sending the task, including input data and requirements.
+     * @return A flow of task update events that emits as the task progresses until completion.
      */
     public fun sendTaskStreaming(params: TaskSendParams): Flow<TaskUpdateEvent>
 
+    /**
+     * Sends a task to the server and subscribes to streaming updates using a pre-constructed request object.
+     *
+     * This method allows for more control over the request, including setting a custom
+     * request ID and complete streaming parameters.
+     *
+     * @param request The fully constructed streaming request containing ID and task parameters.
+     * @return A flow of task update events that emits as the task progresses until completion.
+     */
     public fun sendTaskStreaming(request: SendTaskStreamingRequest): Flow<TaskUpdateEvent>
 
     /**
      * Resubscribes to streaming updates for a task.
      *
-     * @param id The ID of the task.
-     * @return A flow of task update events.
+     * This method reconnects to an existing task's event stream, useful when a previous
+     * streaming connection was lost or closed. It allows clients to resume receiving updates
+     * about task progress without missing events that occurred during the disconnection period.
+     *
+     * @param id The ID of the task to reconnect to.
+     * @return A flow of task update events that continues from the current task state until completion.
      */
     public fun resubscribeToTask(id: TaskId): Flow<TaskUpdateEvent>
 
     /**
      * Closes the client and releases resources.
+     *
+     * This method should be called when the client is no longer needed to ensure
+     * proper cleanup of network connections and other resources. After closing,
+     * the client instance should not be used for any further operations.
      */
     public fun close()
 }

--- a/a2a-client/src/commonMain/kotlin/me/kpavlov/a2a/client/A2AClient.kt
+++ b/a2a-client/src/commonMain/kotlin/me/kpavlov/a2a/client/A2AClient.kt
@@ -5,11 +5,15 @@ import kotlinx.coroutines.flow.Flow
 import me.kpavlov.aimocks.a2a.model.AgentCard
 import me.kpavlov.aimocks.a2a.model.CancelTaskRequest
 import me.kpavlov.aimocks.a2a.model.CancelTaskResponse
+import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationRequest
 import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationResponse
 import me.kpavlov.aimocks.a2a.model.GetTaskRequest
 import me.kpavlov.aimocks.a2a.model.GetTaskResponse
 import me.kpavlov.aimocks.a2a.model.PushNotificationConfig
+import me.kpavlov.aimocks.a2a.model.SendTaskRequest
 import me.kpavlov.aimocks.a2a.model.SendTaskResponse
+import me.kpavlov.aimocks.a2a.model.SendTaskStreamingRequest
+import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationRequest
 import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationResponse
 import me.kpavlov.aimocks.a2a.model.TaskId
 import me.kpavlov.aimocks.a2a.model.TaskSendParams
@@ -43,6 +47,8 @@ public interface A2AClient {
      * @return The response containing the task.
      */
     public suspend fun sendTask(params: TaskSendParams): SendTaskResponse
+
+    public suspend fun sendTask(request: SendTaskRequest): SendTaskResponse
 
     /**
      * Gets a task from the server.
@@ -86,6 +92,8 @@ public interface A2AClient {
         config: PushNotificationConfig,
     ): SetTaskPushNotificationResponse
 
+    public suspend fun setTaskPushNotification(request: SetTaskPushNotificationRequest): SetTaskPushNotificationResponse
+
     /**
      * Gets the push notification configuration for a task.
      *
@@ -94,6 +102,8 @@ public interface A2AClient {
      */
     public suspend fun getTaskPushNotification(id: TaskId): GetTaskPushNotificationResponse
 
+    public suspend fun getTaskPushNotification(request: GetTaskPushNotificationRequest): GetTaskPushNotificationResponse
+
     /**
      * Sends a task to the server and subscribes to streaming updates.
      *
@@ -101,6 +111,8 @@ public interface A2AClient {
      * @return A flow of task update events.
      */
     public fun sendTaskStreaming(params: TaskSendParams): Flow<TaskUpdateEvent>
+
+    public fun sendTaskStreaming(request: SendTaskStreamingRequest): Flow<TaskUpdateEvent>
 
     /**
      * Resubscribes to streaming updates for a task.

--- a/a2a-client/src/commonMain/kotlin/me/kpavlov/a2a/client/A2AClientFactory.kt
+++ b/a2a-client/src/commonMain/kotlin/me/kpavlov/a2a/client/A2AClientFactory.kt
@@ -1,6 +1,7 @@
 package me.kpavlov.a2a.client
 
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.DEFAULT
@@ -8,6 +9,7 @@ import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.sse.SSE
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
@@ -22,6 +24,8 @@ public object A2AClientFactory {
      * @param baseUrl The base URL of the A2A server.
      * @param httpClient An optional HttpClient to use. If not provided, a new one will be created.
      * @param json An optional Json serializer/deserializer to use. If not provided, a new one will be created.
+     * @param defaultRequestConfigurer An optional function to configure the default request.
+     * @param requestConfigurer An optional function to configure each request.
      * @return A new instance of the A2AClient.
      */
     @JvmStatic
@@ -35,6 +39,8 @@ public object A2AClientFactory {
                 isLenient = true
                 prettyPrint = true
             },
+        defaultRequestConfigurer: DefaultRequest.DefaultRequestBuilder.() -> Unit = { },
+        requestConfigurer: HttpRequestBuilder.() -> Unit = { },
     ): A2AClient {
         val client =
             httpClient ?: HttpClient {
@@ -52,6 +58,7 @@ public object A2AClientFactory {
                 defaultRequest {
                     url(baseUrl)
                     headers.append(HttpHeaders.UserAgent, "mokksy-a2a-client")
+                    defaultRequestConfigurer.invoke(this)
                 }
             }
 
@@ -59,6 +66,7 @@ public object A2AClientFactory {
             httpClient = client,
             baseUrl = baseUrl,
             json = json,
+            requestConfigurer = requestConfigurer,
         )
     }
 }

--- a/a2a-client/src/jvmTest/java/me/kpavlov/a2a/client/AbstractJavaTest.java
+++ b/a2a-client/src/jvmTest/java/me/kpavlov/a2a/client/AbstractJavaTest.java
@@ -13,8 +13,8 @@ abstract class AbstractJavaTest {
     protected final Logger logger = LoggerFactory.getLogger(getClass());
     protected final MockAgentServer a2aServer = new MockAgentServer(0, true);
 
-    // Create the client with the baseUrl parameter and a Json object from the JavaTestHelper
-    protected final A2AClient client = A2AClientFactory.create(a2aServer.baseUrl(), null, JavaTestHelper.createJson());
+    // Create the client with the baseUrl parameter set to the mock server's URL
+    protected final A2AClient client = A2AClientFactory.create(a2aServer.baseUrl());
 
     @AfterEach
     public void afterEach() {

--- a/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/AbstractTest.kt
+++ b/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/AbstractTest.kt
@@ -1,14 +1,24 @@
 package me.kpavlov.a2a.client
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.client.request.header
 import me.kpavlov.aimocks.a2a.MockAgentServer
 import org.junit.jupiter.api.AfterEach
+import java.util.UUID
 
 internal abstract class AbstractTest {
     protected val logger = KotlinLogging.logger(name = javaClass.canonicalName!!)
     protected val a2aServer = MockAgentServer(verbose = true)
 
-    protected val client = A2AClientFactory.create(baseUrl = a2aServer.baseUrl())
+    protected val client = A2AClientFactory.create(
+        baseUrl = a2aServer.baseUrl(),
+        defaultRequestConfigurer = {
+            header("X-Test-Header", "test-header-value")
+        },
+        requestConfigurer = {
+            header("X-Request-ID", "${UUID.randomUUID()}")
+        }
+    )
 
     @AfterEach
     fun afterEach() {

--- a/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/AgentCardTest.kt
+++ b/a2a-client/src/jvmTest/kotlin/me/kpavlov/a2a/client/AgentCardTest.kt
@@ -43,7 +43,7 @@ internal class AgentCardTest : AbstractTest() {
                         }
                 }
 
-            a2aServer.agentCard() responds {
+            a2aServer.agentCard(name = agentCard.name) responds {
                 delay = 1.milliseconds
                 card = agentCard
             }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskStreamingRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendTaskStreamingRequest.kt
@@ -29,7 +29,7 @@ public data class SendTaskStreamingRequest(
     val method: String = "tasks/sendSubscribe",
     @SerialName("params")
     val params: TaskSendParams,
-) {
+) : A2ARequest {
     init {
         require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
         require(method == "tasks/sendSubscribe") {

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
@@ -13,7 +13,7 @@ import me.kpavlov.aimocks.core.AbstractBuildingStep
 import me.kpavlov.aimocks.core.AbstractMockLlm
 import me.kpavlov.mokksy.ServerConfiguration
 
-public open class MockAgentServer(
+public open class MockAgentServer @JvmOverloads constructor(
     port: Int = 0,
     verbose: Boolean = false,
 ) : AbstractMockLlm(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ anthropic-java-client-okhttp = { group = "com.anthropic", name="anthropic-java-c
 anthropic-java-core = { group = "com.anthropic", name="anthropic-java-core", version.ref="anthropic-java" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 assertk = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertk" }
+awaitility = { group = "org.awaitility", name = "awaitility", version.ref = "awaitility" }
 awaitility-kotlin = { group = "org.awaitility", name = "awaitility-kotlin", version.ref = "awaitility" }
 datafaker = { module = "net.datafaker:datafaker", version.ref = "datafaker" }
 finchly = { module = "me.kpavlov.finchly:finchly", version.ref = "finchly" }

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/BuildingStep.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/BuildingStep.kt
@@ -53,11 +53,11 @@ public class BuildingStep<P : Any> internal constructor(
      */
     public infix fun <T : Any> respondsWith(block: ResponseDefinitionBuilder<P, T>.() -> Unit) {
         val stub =
-            Stub<P, T>(
+            Stub(
                 configuration = configuration,
                 requestSpecification = requestSpecification,
             ) { call ->
-                val req = CapturedRequest<P>(call.request, requestType)
+                val req = CapturedRequest(call.request, requestType)
                 ResponseDefinitionBuilder<P, T>(request = req)
                     .apply(block)
                     .build()
@@ -69,7 +69,7 @@ public class BuildingStep<P : Any> internal constructor(
         @Suppress("unused") responseType: KClass<T>,
         block: ResponseDefinitionBuilder<P, T>.() -> Unit,
     ) {
-        respondsWith<T>(block)
+        respondsWith(block)
     }
 
     /**
@@ -85,11 +85,11 @@ public class BuildingStep<P : Any> internal constructor(
         block: StreamingResponseDefinitionBuilder<P, T>.() -> Unit,
     ) {
         val stub =
-            Stub<P, T>(
+            Stub(
                 configuration = configuration,
                 requestSpecification = requestSpecification,
             ) { call ->
-                val req = CapturedRequest<P>(call.request, requestType)
+                val req = CapturedRequest(call.request, requestType)
                 StreamingResponseDefinitionBuilder<P, T>(request = req)
                     .apply(block)
                     .build()
@@ -102,7 +102,7 @@ public class BuildingStep<P : Any> internal constructor(
         @Suppress("unused") responseType: KClass<T>,
         block: StreamingResponseDefinitionBuilder<P, T>.() -> Unit,
     ) {
-        respondsWithStream<T>(block)
+        respondsWithStream(block)
     }
 
     /**

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/MokksyServer.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/MokksyServer.kt
@@ -26,15 +26,17 @@ import me.kpavlov.mokksy.request.methodEqual
 import java.util.concurrent.ConcurrentSkipListSet
 import kotlin.reflect.KClass
 
+private const val DEFAULT_HOST = "0.0.0.0"
+
 internal expect fun createEmbeddedServer(
-    host: String = "0.0.0.0",
+    host: String = DEFAULT_HOST,
     port: Int,
     configuration: ServerConfiguration,
     module: Application.() -> Unit,
 ): EmbeddedServer<
     out ApplicationEngine,
     out ApplicationEngine.Configuration,
->
+    >
 
 internal expect fun configureContentNegotiation(config: ContentNegotiationConfig)
 
@@ -50,609 +52,610 @@ internal expect fun configureContentNegotiation(config: ContentNegotiationConfig
  */
 @Suppress("TooManyFunctions")
 public open class MokksyServer
+@JvmOverloads
+constructor(
+    port: Int = 0,
+    host: String = DEFAULT_HOST,
+    configuration: ServerConfiguration,
+    wait: Boolean = false,
+    configurer: (Application) -> Unit = {},
+) {
+    /**
+     *  @constructor Initializes the server with the specified parameters and starts it.
+     *  @param port The port number on which the server will run. Defaults to 0 (randomly assigned port).
+     *  @param verbose A flag indicating whether detailed logs should be printed. Defaults to false.
+     *  @param wait Determines whether the server startup process should block the current thread.
+     *  Defaults to false.
+     *  @param configurer A lambda function for setting custom configurations for the server's application module.
+     */
     @JvmOverloads
-    constructor(
+    public constructor(
         port: Int = 0,
-        host: String = "0.0.0.0",
-        configuration: ServerConfiguration,
-        wait: Boolean = false,
+        host: String = DEFAULT_HOST,
+        verbose: Boolean = false,
         configurer: (Application) -> Unit = {},
-    ) {
-        /**
-         *  @constructor Initializes the server with the specified parameters and starts it.
-         *  @param port The port number on which the server will run. Defaults to 0 (randomly assigned port).
-         *  @param verbose A flag indicating whether detailed logs should be printed. Defaults to false.
-         *  @param wait Determines whether the server startup process should block the current thread.
-         *  Defaults to false.
-         *  @param configurer A lambda function for setting custom configurations for the server's application module.
-         */
-        @JvmOverloads
-        public constructor(
-            port: Int = 0,
-            host: String = "0.0.0.0",
-            verbose: Boolean = false,
-            configurer: (Application) -> Unit = {},
-        ) : this(
-            port = port,
+    ) : this(
+        port = port,
+        host = host,
+        configuration = ServerConfiguration(verbose = verbose),
+        wait = false,
+        configurer = configurer,
+    )
+
+    private var resolvedPort: Int
+
+    private val server =
+        createEmbeddedServer(
             host = host,
-            configuration = ServerConfiguration(verbose = verbose),
-            wait = false,
-            configurer = configurer,
-        )
+            port = port,
+            configuration = configuration,
+        ) {
+            install(SSE)
 
-        private var resolvedPort: Int
+            install(DoubleReceive)
 
-        private val server =
-            createEmbeddedServer(
-                host = host,
-                port = port,
-                configuration = configuration,
-            ) {
-                install(SSE)
+            install(ContentNegotiation) {
+                configuration.contentNegotiationConfigurer(this)
+            }
 
-                install(DoubleReceive)
-
-                install(ContentNegotiation) {
-                    configuration.contentNegotiationConfigurer(this)
-                }
-
-                routing {
-                    route("{...}") {
-                        handle {
-                            handleRequest(
-                                context = this@handle,
-                                application = this@createEmbeddedServer,
-                                stubs = stubs,
-                                configuration = configuration,
-                            )
-                        }
+            routing {
+                route("{...}") {
+                    handle {
+                        handleRequest(
+                            context = this@handle,
+                            application = this@createEmbeddedServer,
+                            stubs = stubs,
+                            configuration = configuration,
+                        )
                     }
                 }
-                configurer(this)
             }
-
-        private val stubs = ConcurrentSkipListSet<Stub<*, *>>()
-
-        init {
-            server.start(wait = wait)
-            runBlocking {
-                resolvedPort =
-                    server.engine
-                        .resolvedConnectors()
-                        .first()
-                        .port
-            }
+            configurer(this)
         }
 
-        /**
-         * Registers a stub in the collection of stubs.
-         * Ensures that duplicates are not allowed.
-         *
-         * @param stub The stub instance to be added to the collection.
-         */
-        private fun registerStub(stub: Stub<*, *>) {
-            val added = stubs.add(stub)
-            assert(added) { "Duplicate stub detected: $stub" }
-        }
+    private val stubs = ConcurrentSkipListSet<Stub<*, *>>()
 
-        /**
-         * Retrieves the resolved port on which the server is running.
-         *
-         * @return The currently configured port number for the server.
-         */
-        public fun port(): Int = resolvedPort
-
-        /**
-         * Creates a `RequestSpecification` with the specified HTTP method and additional configuration
-         * defined by the given block, and returns a new `BuildingStep` instance for further customization.
-         *
-         * * @param name An optional name assigned to the Stub for identification or debugging purposes.
-         * @param httpMethod The `HttpMethod` to match for the request specification.
-         *  @param requestType The class type of the request body.
-         * @param block A lambda used to configure the `RequestSpecificationBuilder`.
-         * @return A [BuildingStep] instance initialized with the generated request specification.
-         */
-        public fun <P : Any> method(
-            configuration: StubConfiguration,
-            httpMethod: HttpMethod,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> {
-            val requestSpec =
-                RequestSpecificationBuilder<P>(requestType)
-                    .apply(block)
-                    .method(methodEqual(httpMethod))
-                    .build()
-
-            return BuildingStep<P>(
-                configuration = configuration,
-                requestSpecification = requestSpec,
-                registerStub = this::registerStub,
-                requestType = requestType,
-            )
-        }
-
-        /**
-         * Creates a building step for a stub configuration with the specified parameters.
-         *
-         * @param name An optional name for the stub configuration.
-         * @param httpMethod The HTTP method associated with the request.
-         * @param requestType The class type of the request payload.
-         * @param block A block for specifying request details using a RequestSpecificationBuilder.
-         * @return A BuildingStep instance configured with the provided parameters.
-         */
-        public fun <P : Any> method(
-            name: String? = null,
-            httpMethod: HttpMethod,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = StubConfiguration(name = name),
-                httpMethod = httpMethod,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Configures an HTTP GET request specification using the provided block and returns a `BuildingStep`
-         * instance for further customization.
-         *
-         * @param P type of the request payload
-         * @param requestType The class type of the request body.
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun <P : Any> get(
-            configuration: StubConfiguration,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = configuration,
-                httpMethod = Get,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Configures an HTTP GET request specification using the provided block and returns a `BuildingStep`
-         * instance for further customization.
-         *
-         * @param P type of the request payload
-         * @param requestType The class type of the request body.
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun <P : Any> get(
-            name: String? = null,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = StubConfiguration(name),
-                httpMethod = Get,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Configures HTTP GET request specification using the provided block and returns a `BuildingStep`
-         * for further customization. This method serves as a convenience shortcut.
-         *
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun get(
-            block: RequestSpecificationBuilder<String>.() -> Unit,
-        ): BuildingStep<String> =
-            this.get<String>(
-                name = null,
-                requestType = String::class,
-                block = block,
-            )
-
-        /**
-         * Configures HTTP GET request specification using the provided block and returns a `BuildingStep`
-         * for further customization. This method serves as a convenience shortcut.
-         *
-         * @param configuration The configuration to be used for the request.
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
-         * @return A [BuildingStep] instance initialized with the generated request specification.
-         */
-        public fun get(
-            configuration: StubConfiguration,
-            block: RequestSpecificationBuilder<String>.() -> Unit,
-        ): BuildingStep<String> =
-            this.get<String>(
-                configuration = configuration,
-                requestType = String::class,
-                block = block,
-            )
-
-        /**
-         * Configures an HTTP POST request specification using the provided block and returns a `BuildingStep`
-         * instance for further customization. This method utilizes the HTTP POST method to define the request
-         * specification within the provided lambda.
-         *
-         * @param P type of the request payload.
-         * @param requestType The class type of the request body.
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the POST request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun <P : Any> post(
-            name: String? = null,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = StubConfiguration(name),
-                httpMethod = Post,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Sends a POST request using the provided configuration,
-         * request type, and block to define the request specification.
-         *
-         * @param configuration The configuration settings for the request, including endpoint and other details.
-         * @param requestType The class type of the request body.
-         * @param block A lambda function to define the specifics of the request, such as headers, query parameters, etc.
-         * @return A [BuildingStep] instance representing the constructed POST request.
-         */
-        public fun <P : Any> post(
-            configuration: StubConfiguration,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = configuration,
-                httpMethod = Post,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Configures an HTTP POST request specification using the provided block and returns a `BuildingStep`
-         * for further customization. This method serves as a convenience shortcut.
-         *
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun post(
-            block: RequestSpecificationBuilder<String>.() -> Unit,
-        ): BuildingStep<String> = this.post(name = null, requestType = String::class, block = block)
-
-        /**
-         * Configures an HTTP DELETE request specification using the provided block and returns a `BuildingStep`
-         * instance for further customization. This method utilizes the HTTP DELETE method to define the request
-         * specification within the provided lambda.
-         *
-         * @param P type of the request payload.
-         * @param requestType The class type of the request body.
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the DELETE request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun <P : Any> delete(
-            name: String? = null,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = StubConfiguration(name),
-                httpMethod = Delete,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Executes an HTTP DELETE request with the specified configuration and request type.
-         *
-         * @param configuration The configuration settings for the request.
-         * @param requestType The class of the request type that will be processed.
-         * @param block A lambda to configure the request specification for the DELETE request.
-         * @return A BuildingStep instance representing the configured DELETE request.
-         */
-        public fun <P : Any> delete(
-            configuration: StubConfiguration,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = configuration,
-                httpMethod = Delete,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Configures an HTTP DELETE request specification using the provided block and returns a `BuildingStep`
-         * for further customization. This method serves as a convenience shortcut.
-         *
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun delete(
-            block: RequestSpecificationBuilder<String>.() -> Unit,
-        ): BuildingStep<String> =
-            this.delete(name = null, requestType = String::class, block = block)
-
-        /**
-         * Configures an HTTP PATCH request specification using the provided block and returns a `BuildingStep`
-         * instance for further customization. This method uses the HTTP PATCH method to define the request
-         * specification within the provided lambda.
-         *
-         * @param P type of the request payload.
-         *  @param requestType The class type of the request body.
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the PATCH request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun <P : Any> patch(
-            name: String? = null,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = StubConfiguration(name),
-                httpMethod = Patch,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Builds and returns a BuildingStep for a PATCH HTTP request with the provided configuration, request type,
-         * and custom request specification block.
-         *
-         * @param configuration The stub configuration that contains the setup details for the request.
-         * @param requestType The KClass type of the request body.
-         * @param block A lambda block to define the request specification.
-         * @return A [BuildingStep] instance representing the constructed PATCH request.
-         */
-        public fun <P : Any> patch(
-            configuration: StubConfiguration,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = configuration,
-                httpMethod = Patch,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Configures an HTTP PATCH request specification using the provided block and returns a `BuildingStep`
-         * for further customization. This method serves as a convenience shortcut.
-         *
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun patch(
-            block: RequestSpecificationBuilder<String>.() -> Unit,
-        ): BuildingStep<String> =
-            this.patch(name = null, requestType = String::class, block = block)
-
-        /**
-         * Configures an HTTP PUT request specification using the provided block and returns a `BuildingStep`
-         * instance for further customization. This method utilizes the HTTP PUT method to define the request
-         * specification within the provided lambda.
-         *
-         * @param P type of the request payload
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the PUT request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun <P : Any> put(
-            name: String? = null,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = StubConfiguration(name),
-                httpMethod = Put,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Executes an HTTP PUT request with the provided configuration and request specifications.
-         *
-         * @param configuration The stub configuration to be used for the request.
-         * @param requestType The class type of the request payload.
-         * @param block A configuration block to build the request specifications.
-         * @return A [BuildingStep] instance for further processing of the request.
-         */
-        public fun <P : Any> put(
-            configuration: StubConfiguration,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = configuration,
-                httpMethod = Put,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Configures an HTTP PUT request specification using the provided block and returns a `BuildingStep`
-         * for further customization. This method serves as a convenience shortcut.
-         *
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun put(
-            block: RequestSpecificationBuilder<String>.() -> Unit,
-        ): BuildingStep<String> = this.put(name = null, requestType = String::class, block = block)
-
-        /**
-         * Configures an HTTP HEAD request specification using the provided block and returns a `BuildingStep`
-         * instance for further customization. This method utilizes the HTTP HEAD method to define the request
-         * specification within the provided lambda.
-         *
-         * @param P type of the request payload
-         *  @param requestType The class type of the request body.
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the HEAD request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun <P : Any> head(
-            name: String? = null,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = StubConfiguration(name),
-                httpMethod = Head,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Constructs a HEAD HTTP request with the provided configuration, request type, and specification block.
-         *
-         * @param configuration The configuration for the stubbed request.
-         * @param requestType The class type of the request payload.
-         * @param block A lambda that specifies the request parameters.
-         * @return A [BuildingStep] instance representing the constructed request.
-         */
-        public fun <P : Any> head(
-            configuration: StubConfiguration,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = configuration,
-                httpMethod = Head,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Configures an HTTP HEAD request specification using the provided block and returns a `BuildingStep`
-         * for further customization. This method serves as a convenience shortcut.
-         *
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun head(
-            block: RequestSpecificationBuilder<String>.() -> Unit,
-        ): BuildingStep<String> = this.head(name = null, requestType = String::class, block = block)
-
-        /**
-         * Configures an HTTP OPTIONS request specification using the provided block and returns a `BuildingStep`
-         * instance for further customization. This method uses the HTTP OPTIONS method to define the request
-         * specification within the provided lambda.
-         *
-         * @param P type of the request payload
-         *  @param requestType The class type of the request body.
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the OPTIONS request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun <P : Any> options(
-            name: String? = null,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = StubConfiguration(name),
-                httpMethod = Options,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Configures and executes an HTTP OPTIONS request based on the given parameters.
-         *
-         * @param configuration The configuration settings to use for the request.
-         * @param requestType The class type of the request body.
-         * @param block A lambda to build and modify the request specifications.
-         * @return A [BuildingStep] object representing the state after configuring the OPTIONS request.
-         */
-        public fun <P : Any> options(
-            configuration: StubConfiguration,
-            requestType: KClass<P>,
-            block: RequestSpecificationBuilder<P>.() -> Unit,
-        ): BuildingStep<P> =
-            method(
-                configuration = configuration,
-                httpMethod = Options,
-                requestType = requestType,
-                block = block,
-            )
-
-        /**
-         * Configures an HTTP HEAD request specification using the provided block and returns a `BuildingStep`
-         * for further customization. This method serves as a convenience shortcut.
-         *
-         * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
-         * @return A `BuildingStep` instance initialized with the generated request specification.
-         */
-        public fun options(
-            block: RequestSpecificationBuilder<String>.() -> Unit,
-        ): BuildingStep<String> =
-            this.options(name = null, requestType = String::class, block = block)
-
-        /**
-         * Retrieves a list of all request specifications that have not been matched to any incoming requests.
-         * A request is considered unmatched if its match count is zero.
-         *
-         * @return A list of unmatched request specifications.
-         */
-        public fun findAllUnmatchedRequests(): List<RequestSpecification<*>> =
-            stubs
-                .filter {
-                    it.matchCount() == 0
-                }.map { it.requestSpecification }
-                .toList()
-
-        /**
-         * Resets the match counts for all mappings in the server. Each mapping's match count
-         * is set to zero, effectively clearing any record of previous matches.
-         *
-         * This is useful for resetting the state of the server when reinitializing or performing
-         * testing scenarios.
-         */
-        public fun resetMatchCounts() {
-            stubs
-                .forEach {
-                    it.resetMatchCount()
-                }
-        }
-
-        /**
-         * Checks for any unmatched requests by retrieving all request specifications that
-         * have not been matched to incoming requests and verifies that the list of unmatched
-         * requests is empty.
-         *
-         * This method ensures that all request mappings have been utilized as expected. If
-         * there are unmatched requests, this would indicate that some defined mappings were
-         * not triggered during the testing or execution process.
-         *
-         * Utilizes the `findAllUnmatchedRequests` function to identify unmatched requests and
-         * asserts that no unmatched requests exist.
-         */
-        public fun checkForUnmatchedRequests() {
-            val unmatchedRequests = findAllUnmatchedRequests()
-            if (unmatchedRequests.isNotEmpty()) {
-                failure(
-                    "The following requests were not matched: ${
-                        unmatchedRequests.joinToString {
-                            it
-                                .toLogString()
-                        }
-                    }",
-                )
-            }
-        }
-
-        /**
-         * Shuts down the server by stopping its execution.
-         *
-         * This method halts any ongoing operations of the server,
-         * effectively terminating its current state and releasing any occupied resources.
-         * It should be invoked to safely stop the server when it is no longer needed.
-         */
-        public fun shutdown() {
-            server.stop()
+    init {
+        server.start(wait = wait)
+        runBlocking {
+            resolvedPort =
+                server.engine
+                    .resolvedConnectors()
+                    .first()
+                    .port
         }
     }
+
+    /**
+     * Registers a stub in the collection of stubs.
+     * Ensures that duplicates are not allowed.
+     *
+     * @param stub The stub instance to be added to the collection.
+     */
+    private fun registerStub(stub: Stub<*, *>) {
+        val added = stubs.add(stub)
+        assert(added) { "Duplicate stub detected: $stub" }
+    }
+
+    /**
+     * Retrieves the resolved port on which the server is running.
+     *
+     * @return The currently configured port number for the server.
+     */
+    public fun port(): Int = resolvedPort
+
+    /**
+     * Creates a `RequestSpecification` with the specified HTTP method and additional configuration
+     * defined by the given block, and returns a new `BuildingStep` instance for further customization.
+     *
+     * * @param name An optional name assigned to the Stub for identification or debugging purposes.
+     * @param httpMethod The `HttpMethod` to match for the request specification.
+     *  @param requestType The class type of the request body.
+     * @param block A lambda used to configure the `RequestSpecificationBuilder`.
+     * @return A [BuildingStep] instance initialized with the generated request specification.
+     */
+    public fun <P : Any> method(
+        configuration: StubConfiguration,
+        httpMethod: HttpMethod,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> {
+        val requestSpec =
+            RequestSpecificationBuilder(requestType)
+                .apply(block)
+                .method(methodEqual(httpMethod))
+                .build()
+
+        return BuildingStep(
+            configuration = configuration,
+            requestSpecification = requestSpec,
+            registerStub = this::registerStub,
+            requestType = requestType,
+        )
+    }
+
+    /**
+     * Creates a building step for a stub configuration with the specified parameters.
+     *
+     * @param name An optional name for the stub configuration.
+     * @param httpMethod The HTTP method associated with the request.
+     * @param requestType The class type of the request payload.
+     * @param block A block for specifying request details using a RequestSpecificationBuilder.
+     * @return A BuildingStep instance configured with the provided parameters.
+     */
+    public fun <P : Any> method(
+        name: String? = null,
+        httpMethod: HttpMethod,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = StubConfiguration(name = name),
+            httpMethod = httpMethod,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Configures an HTTP GET request specification using the provided block and returns a `BuildingStep`
+     * instance for further customization.
+     *
+     * @param P type of the request payload
+     * @param requestType The class type of the request body.
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun <P : Any> get(
+        configuration: StubConfiguration,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = configuration,
+            httpMethod = Get,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Configures an HTTP GET request specification using the provided block and returns a `BuildingStep`
+     * instance for further customization.
+     *
+     * @param P type of the request payload
+     * @param requestType The class type of the request body.
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun <P : Any> get(
+        name: String? = null,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = StubConfiguration(name),
+            httpMethod = Get,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Configures HTTP GET request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun get(
+        block: RequestSpecificationBuilder<String>.() -> Unit,
+    ): BuildingStep<String> =
+        this.get(
+            name = null,
+            requestType = String::class,
+            block = block,
+        )
+
+    /**
+     * Configures HTTP GET request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param configuration The configuration to be used for the request.
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A [BuildingStep] instance initialized with the generated request specification.
+     */
+    public fun get(
+        configuration: StubConfiguration,
+        block: RequestSpecificationBuilder<String>.() -> Unit,
+    ): BuildingStep<String> =
+        this.get(
+            configuration = configuration,
+            requestType = String::class,
+            block = block,
+        )
+
+    /**
+     * Configures an HTTP POST request specification using the provided block and returns a `BuildingStep`
+     * instance for further customization. This method uses the HTTP POST method to define the request
+     * specification within the provided lambda.
+     *
+     * @param P type of the request payload.
+     * @param requestType The class type of the request body.
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the POST request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun <P : Any> post(
+        name: String? = null,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = StubConfiguration(name),
+            httpMethod = Post,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Sends a POST request using the provided configuration,
+     * request type, and block to define the request specification.
+     *
+     * @param configuration The configuration settings for the request, including endpoint and other details.
+     * @param requestType The class type of the request body.
+     * @param block A lambda function to define the specifics of the request,
+     * such as headers, query parameters, etc.
+     * @return A [BuildingStep] instance representing the constructed POST request.
+     */
+    public fun <P : Any> post(
+        configuration: StubConfiguration,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = configuration,
+            httpMethod = Post,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Configures an HTTP POST request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun post(
+        block: RequestSpecificationBuilder<String>.() -> Unit,
+    ): BuildingStep<String> = this.post(name = null, requestType = String::class, block = block)
+
+    /**
+     * Configures an HTTP DELETE request specification using the provided block and returns a `BuildingStep`
+     * instance for further customization. This method uses the HTTP DELETE method to define the request
+     * specification within the provided lambda.
+     *
+     * @param P type of the request payload.
+     * @param requestType The class type of the request body.
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the DELETE request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun <P : Any> delete(
+        name: String? = null,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = StubConfiguration(name),
+            httpMethod = Delete,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Executes an HTTP DELETE request with the specified configuration and request type.
+     *
+     * @param configuration The configuration settings for the request.
+     * @param requestType The class of the request type that will be processed.
+     * @param block A lambda to configure the request specification for the DELETE request.
+     * @return A BuildingStep instance representing the configured DELETE request.
+     */
+    public fun <P : Any> delete(
+        configuration: StubConfiguration,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = configuration,
+            httpMethod = Delete,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Configures an HTTP DELETE request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun delete(
+        block: RequestSpecificationBuilder<String>.() -> Unit,
+    ): BuildingStep<String> =
+        this.delete(name = null, requestType = String::class, block = block)
+
+    /**
+     * Configures an HTTP PATCH request specification using the provided block and returns a `BuildingStep`
+     * instance for further customization. This method uses the HTTP PATCH method to define the request
+     * specification within the provided lambda.
+     *
+     * @param P type of the request payload.
+     *  @param requestType The class type of the request body.
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the PATCH request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun <P : Any> patch(
+        name: String? = null,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = StubConfiguration(name),
+            httpMethod = Patch,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Builds and returns a BuildingStep for a PATCH HTTP request with the provided configuration, request type,
+     * and custom request specification block.
+     *
+     * @param configuration The stub configuration that contains the setup details for the request.
+     * @param requestType The KClass type of the request body.
+     * @param block A lambda block to define the request specification.
+     * @return A [BuildingStep] instance representing the constructed PATCH request.
+     */
+    public fun <P : Any> patch(
+        configuration: StubConfiguration,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = configuration,
+            httpMethod = Patch,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Configures an HTTP PATCH request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun patch(
+        block: RequestSpecificationBuilder<String>.() -> Unit,
+    ): BuildingStep<String> =
+        this.patch(name = null, requestType = String::class, block = block)
+
+    /**
+     * Configures an HTTP PUT request specification using the provided block and returns a `BuildingStep`
+     * instance for further customization. This method uses the HTTP PUT method to define the request
+     * specification within the provided lambda.
+     *
+     * @param P type of the request payload
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the PUT request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun <P : Any> put(
+        name: String? = null,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = StubConfiguration(name),
+            httpMethod = Put,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Executes an HTTP PUT request with the provided configuration and request specifications.
+     *
+     * @param configuration The stub configuration to be used for the request.
+     * @param requestType The class type of the request payload.
+     * @param block A configuration block to build the request specifications.
+     * @return A [BuildingStep] instance for further processing of the request.
+     */
+    public fun <P : Any> put(
+        configuration: StubConfiguration,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = configuration,
+            httpMethod = Put,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Configures an HTTP PUT request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun put(
+        block: RequestSpecificationBuilder<String>.() -> Unit,
+    ): BuildingStep<String> = this.put(name = null, requestType = String::class, block = block)
+
+    /**
+     * Configures an HTTP HEAD request specification using the provided block and returns a `BuildingStep`
+     * instance for further customization. This method uses the HTTP HEAD method to define the request
+     * specification within the provided lambda.
+     *
+     * @param P type of the request payload
+     *  @param requestType The class type of the request body.
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the HEAD request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun <P : Any> head(
+        name: String? = null,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = StubConfiguration(name),
+            httpMethod = Head,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Constructs a HEAD HTTP request with the provided configuration, request type, and specification block.
+     *
+     * @param configuration The configuration for the stubbed request.
+     * @param requestType The class type of the request payload.
+     * @param block A lambda that specifies the request parameters.
+     * @return A [BuildingStep] instance representing the constructed request.
+     */
+    public fun <P : Any> head(
+        configuration: StubConfiguration,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = configuration,
+            httpMethod = Head,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Configures an HTTP HEAD request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun head(
+        block: RequestSpecificationBuilder<String>.() -> Unit,
+    ): BuildingStep<String> = this.head(name = null, requestType = String::class, block = block)
+
+    /**
+     * Configures an HTTP OPTIONS request specification using the provided block and returns a `BuildingStep`
+     * instance for further customization. This method uses the HTTP OPTIONS method to define the request
+     * specification within the provided lambda.
+     *
+     * @param P type of the request payload
+     *  @param requestType The class type of the request body.
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the OPTIONS request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun <P : Any> options(
+        name: String? = null,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = StubConfiguration(name),
+            httpMethod = Options,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Configures and executes an HTTP OPTIONS request based on the given parameters.
+     *
+     * @param configuration The configuration settings to use for the request.
+     * @param requestType The class type of the request body.
+     * @param block A lambda to build and modify the request specifications.
+     * @return A [BuildingStep] object representing the state after configuring the OPTIONS request.
+     */
+    public fun <P : Any> options(
+        configuration: StubConfiguration,
+        requestType: KClass<P>,
+        block: RequestSpecificationBuilder<P>.() -> Unit,
+    ): BuildingStep<P> =
+        method(
+            configuration = configuration,
+            httpMethod = Options,
+            requestType = requestType,
+            block = block,
+        )
+
+    /**
+     * Configures an HTTP HEAD request specification using the provided block and returns a `BuildingStep`
+     * for further customization. This method serves as a convenience shortcut.
+     *
+     * @param block A lambda used to configure the `RequestSpecificationBuilder` for the GET request.
+     * @return A `BuildingStep` instance initialized with the generated request specification.
+     */
+    public fun options(
+        block: RequestSpecificationBuilder<String>.() -> Unit,
+    ): BuildingStep<String> =
+        this.options(name = null, requestType = String::class, block = block)
+
+    /**
+     * Retrieves a list of all request specifications that have not been matched to any incoming requests.
+     * A request is considered unmatched if its match count is zero.
+     *
+     * @return A list of unmatched request specifications.
+     */
+    public fun findAllUnmatchedRequests(): List<RequestSpecification<*>> =
+        stubs
+            .filter {
+                it.matchCount() == 0
+            }.map { it.requestSpecification }
+            .toList()
+
+    /**
+     * Resets the match counts for all mappings in the server. Each mapping's match count
+     * is set to zero, effectively clearing any record of previous matches.
+     *
+     * This is useful for resetting the state of the server when reinitializing or performing
+     * testing scenarios.
+     */
+    public fun resetMatchCounts() {
+        stubs
+            .forEach {
+                it.resetMatchCount()
+            }
+    }
+
+    /**
+     * Checks for any unmatched requests by retrieving all request specifications that
+     * have not been matched to incoming requests and verifies that the list of unmatched
+     * requests is empty.
+     *
+     * This method ensures that all request mappings have been used as expected. If
+     * there are unmatched requests, this would indicate that some defined mappings were
+     * not triggered during the testing or execution process.
+     *
+     * Uses the `findAllUnmatchedRequests` function to identify unmatched requests and
+     * asserts that no unmatched requests exist.
+     */
+    public fun checkForUnmatchedRequests() {
+        val unmatchedRequests = findAllUnmatchedRequests()
+        if (unmatchedRequests.isNotEmpty()) {
+            failure(
+                "The following requests were not matched: ${
+                    unmatchedRequests.joinToString {
+                        it
+                            .toLogString()
+                    }
+                }",
+            )
+        }
+    }
+
+    /**
+     * Shuts down the server by stopping its execution.
+     *
+     * This method halts any ongoing operations of the server,
+     * effectively terminating its current state and releasing any occupied resources.
+     * It should be invoked to safely stop the server when it is no longer necessary.
+     */
+    public fun shutdown() {
+        server.stop()
+    }
+}

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/kotest/Matchers.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/kotest/Matchers.kt
@@ -14,7 +14,7 @@ import io.kotest.matchers.MatcherResult
  * @return A Matcher instance that evaluates the given condition.
  */
 public fun doesNotContainIgnoringCase(substr: String): Matcher<String?> =
-    Matcher<String?> { value ->
+    Matcher { value ->
         MatcherResult(
             value == null || value.lowercase().indexOf(substr.lowercase()) == -1,
             {
@@ -35,7 +35,7 @@ public fun doesNotContainIgnoringCase(substr: String): Matcher<String?> =
  * @return A Matcher instance that evaluates the given condition.
  */
 public fun doesNotContain(substr: String): Matcher<String?> =
-    Matcher<String?> { value ->
+    Matcher { value ->
         MatcherResult(
             value == null || value.indexOf(substr) == -1,
             {

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/RequestSpecification.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/RequestSpecification.kt
@@ -181,7 +181,7 @@ public open class RequestSpecificationBuilder<P : Any>(
      *         for further customization.
      */
     public fun bodyMatchesPredicate(predicate: (P?) -> Boolean): RequestSpecificationBuilder<P> {
-        this.body += predicateMatcher<P?>(predicate)
+        this.body += predicateMatcher(predicate)
         return this
     }
 
@@ -222,7 +222,7 @@ public open class RequestSpecificationBuilder<P : Any>(
     }
 
     internal fun build(): RequestSpecification<P> =
-        RequestSpecification<P>(
+        RequestSpecification(
             method = method,
             path = path,
             headers = headers,

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/AbstractResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/AbstractResponseDefinition.kt
@@ -25,7 +25,7 @@ public abstract class AbstractResponseDefinition<T>(
     public val contentType: ContentType? = null,
     public val httpStatus: HttpStatusCode = HttpStatusCode.OK,
     public val headers: (ResponseHeaders.() -> Unit)? = null,
-    public val headerList: List<Pair<String, String>> = emptyList<Pair<String, String>>(),
+    public val headerList: List<Pair<String, String>> = emptyList(),
     public open val delay: Duration = Duration.ZERO,
 ) {
     internal abstract suspend fun writeResponse(

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/ResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/ResponseDefinition.kt
@@ -22,7 +22,7 @@ import kotlin.time.Duration
  * @property headers A lambda function for configuring additional response headers using [ResponseHeaders].
  * Defaults to null.
  * @property headerList A list of additional header key-value pairs. Defaults to an empty list.
- * @property delay Delay before response is sent. Default value is zero.
+ * @property delay Delay before the response is sent. The default value is zero.
  */
 public open class ResponseDefinition<P, T>(
     contentType: ContentType = ContentType.Application.Json,

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/ResponseDefinitionBuilders.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/response/ResponseDefinitionBuilders.kt
@@ -82,7 +82,7 @@ public open class ResponseDefinitionBuilder<P : Any, T : Any>(
     headers: MutableList<Pair<String, String>> = mutableListOf(),
 ) : AbstractResponseDefinitionBuilder<P, T>(httpStatus = httpStatus, headers = headers) {
     public override fun build(): ResponseDefinition<P, T> =
-        ResponseDefinition<P, T>(
+        ResponseDefinition(
             body = body,
             contentType = contentType ?: ContentType.Application.Json,
             httpStatus = httpStatus,
@@ -126,7 +126,7 @@ public open class StreamingResponseDefinitionBuilder<P : Any, T>(
      * @return A fully constructed `StreamResponseDefinition` instance containing the configured response details.
      */
     public override fun build(): StreamResponseDefinition<P, T> =
-        StreamResponseDefinition<P, T>(
+        StreamResponseDefinition(
             chunkFlow = flow,
             chunks = chunks.toList(),
             httpStatus = httpStatus,

--- a/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/AbstractIT.kt
+++ b/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/AbstractIT.kt
@@ -22,7 +22,7 @@ internal abstract class AbstractIT(
     protected val logger = KotlinLogging.logger(name = this::class.simpleName!!)
 
     /**
-     * Represents a seed value that is used for random number generation in tests.
+     * Represents a seed value is used for random number generation in tests.
      * Initialized to `-1` by default, it is updated before each test execution to a random value.
      * This ensures variability and uniqueness for random-based operations during every test run.
      */

--- a/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/RequestSpecificationTest.kt
+++ b/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/RequestSpecificationTest.kt
@@ -47,7 +47,7 @@ class RequestSpecificationTest {
                 every { headersMatcher.test(any()).passed() } returns true
 
                 val spec =
-                    RequestSpecification<Input>(
+                    RequestSpecification(
                         method = beEqual(HttpMethod.Get),
                         path = contain("test"),
                         headers = listOf(headersMatcher),
@@ -69,7 +69,7 @@ class RequestSpecificationTest {
 
                 val headersMatcher = mockk<Matcher<Headers>>(relaxed = true)
                 val spec =
-                    RequestSpecification<Input>(
+                    RequestSpecification(
                         headers = listOf(headersMatcher),
                         requestType = Input::class,
                     )
@@ -87,7 +87,7 @@ class RequestSpecificationTest {
             runTest {
                 every { request.httpMethod } returns HttpMethod.Get
                 val spec =
-                    RequestSpecification<Input>(
+                    RequestSpecification(
                         method = beEqual(HttpMethod.Post),
                         path = contain("test"),
                         requestType = Input::class,
@@ -103,7 +103,7 @@ class RequestSpecificationTest {
                 every { request.path() } returns "/test"
 
                 val spec =
-                    RequestSpecification<Input>(
+                    RequestSpecification(
                         method = beEqual(HttpMethod.Get),
                         path = contain("differentPath"),
                         requestType = Input::class,
@@ -122,7 +122,7 @@ class RequestSpecificationTest {
 
                 val headersMatcher = mockk<Matcher<Headers>>(relaxed = true)
                 val spec =
-                    RequestSpecification<Input>(
+                    RequestSpecification(
                         headers = listOf(headersMatcher),
                         requestType = Input::class,
                     )
@@ -139,7 +139,7 @@ class RequestSpecificationTest {
 
                 val bodyMatcher = contain("expectedBody")
                 val spec =
-                    RequestSpecification<String>(
+                    RequestSpecification(
                         bodyString = listOf(bodyMatcher),
                         requestType = String::class,
                     )
@@ -156,7 +156,7 @@ class RequestSpecificationTest {
 
                 val bodyMatcher: Matcher<Input?> = beEqual(Input("Bob"))
                 val spec =
-                    RequestSpecification<Input>(
+                    RequestSpecification(
                         body = listOf(bodyMatcher),
                         requestType = Input::class,
                     )

--- a/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/request/RequestMarchersKtTest.kt
+++ b/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/request/RequestMarchersKtTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 class RequestMarchersKtTest {
     private val predicate: (Input?) -> Boolean =
         object : (Input?) -> Boolean {
-            override fun invoke(p1: Input?): Boolean = (p1?.name == "foo") == true
+            override fun invoke(p1: Input?): Boolean = (p1?.name == "foo")
 
             override fun toString(): String = "predicateToString"
         }

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/BodyMatchingIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/BodyMatchingIT.kt
@@ -35,7 +35,7 @@ internal class BodyMatchingIT : AbstractIT() {
             val expectedResponse = TestPerson.random()
 
             mokksy
-                .post<Input>(name = "predicate", Input::class) {
+                .post(name = "predicate", Input::class) {
                     path("/predicate")
 
                     bodyMatchesPredicate {

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/MokksySseIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/MokksySseIT.kt
@@ -21,7 +21,7 @@ internal class MokksySseIT : AbstractIT({ createKtorSSEClient(it) }) {
     @Test
     fun `Should respond to SSE (flow)`() =
         runTest {
-            mokksy.get<Any>(name = "sse-get-flow", requestType = Any::class) {
+            mokksy.get(name = "sse-get-flow", requestType = Any::class) {
                 path = beEqual("/sse-flow")
             } respondsWithSseStream {
                 flow =
@@ -48,7 +48,7 @@ internal class MokksySseIT : AbstractIT({ createKtorSSEClient(it) }) {
     @Test
     fun `Should respond to SSE (chunks)`() =
         runTest {
-            mokksy.get<Any>(name = "sse-get-chunks", requestType = Any::class) {
+            mokksy.get(name = "sse-get-chunks", requestType = Any::class) {
                 path = beEqual("/sse-chunks")
             } respondsWithSseStream {
                 chunks += ServerSentEvent(data = "One")

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/MokksyStreamingIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/MokksyStreamingIT.kt
@@ -49,7 +49,7 @@ internal class MokksyStreamingIT : AbstractIT({ createKtorSSEClient(it) }) {
     fun `Should respond to stream of Strings (chunks)`() =
         runTest {
             mokksy.get {
-                path = beEqual("/streaming-chunks")
+                path("/streaming-chunks")
             } respondsWithStream {
                 chunks += "One"
                 chunks += "Two"

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/RemoveAfterUseIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/RemoveAfterUseIT.kt
@@ -1,6 +1,5 @@
 package me.kpavlov.mokksy
 
-import io.kotest.matchers.equals.beEqual
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
@@ -20,13 +19,13 @@ internal class RemoveAfterUseIT : AbstractIT() {
                             verbose = true,
                         ),
                 ) {
-                    path = beEqual(uri)
+                    path(uri)
                 }.respondsWith(String::class) {
                     body = "🇪🇪 Tere!"
                 }
-            // First request should succeed
+            // The first request should succeed
             client.get(uri).status shouldBe HttpStatusCode.OK
-            // Next request should fail as stub is self-removed
+            // The next request should fail as stub is self-removed
             client.get(uri).status shouldBe HttpStatusCode.NotFound
         }
 }

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/StubComparatorTest.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/StubComparatorTest.kt
@@ -28,7 +28,7 @@ internal class StubComparatorTest {
         request2 = RequestSpecification(priority = 1, requestType = Int::class)
 
         val stub1 =
-            Stub<Int, String>(
+            Stub(
                 configuration = config,
                 requestSpecification = request1,
                 responseDefinitionSupplier = responseDefinitionSupplier,

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/TypesafeMethodsIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/TypesafeMethodsIT.kt
@@ -48,32 +48,32 @@ internal class TypesafeMethodsIT : AbstractIT() {
     fun `Should respond to Method`(methodName: String) =
         runTest {
             val method = HttpMethod.parse(methodName)
-            doTestCallMethod<TestPerson>(method) {
-                mokksy.method<TestPerson>(name, method, TestPerson::class, it)
+            doTestCallMethod(method) {
+                mokksy.method(name, method, TestPerson::class, it)
             }
         }
 
     @Test
     fun `Should respond to GET`() =
         runTest {
-            doTestCallMethod<TestPerson>(
+            doTestCallMethod(
                 HttpMethod.Get,
-            ) { mokksy.get<TestPerson>(name, TestPerson::class, it) }
+            ) { mokksy.get(name, TestPerson::class, it) }
         }
 
     @Test
     fun `Should respond to OPTIONS`() =
         runTest {
-            doTestCallMethod<TestPerson>(
+            doTestCallMethod(
                 HttpMethod.Options,
-            ) { mokksy.options<TestPerson>(name, TestPerson::class, it) }
+            ) { mokksy.options(name, TestPerson::class, it) }
         }
 
     @Test
     fun `Should respond to PUT`() =
         runTest {
-            doTestCallMethod<TestPerson>(HttpMethod.Put) {
-                mokksy.put<TestPerson>(
+            doTestCallMethod(HttpMethod.Put) {
+                mokksy.put(
                     name,
                     TestPerson::class,
                     it,
@@ -84,8 +84,8 @@ internal class TypesafeMethodsIT : AbstractIT() {
     @Test
     fun `Should respond to PATCH`() =
         runTest {
-            doTestCallMethod<TestPerson>(HttpMethod.Patch) {
-                mokksy.patch<TestPerson>(
+            doTestCallMethod(HttpMethod.Patch) {
+                mokksy.patch(
                     name,
                     TestPerson::class,
                     it,
@@ -96,8 +96,8 @@ internal class TypesafeMethodsIT : AbstractIT() {
     @Test
     fun `Should respond to DELETE`() =
         runTest {
-            doTestCallMethod<TestPerson>(HttpMethod.Delete) {
-                mokksy.delete<TestPerson>(
+            doTestCallMethod(HttpMethod.Delete) {
+                mokksy.delete(
                     name,
                     TestPerson::class,
                     it,
@@ -108,8 +108,8 @@ internal class TypesafeMethodsIT : AbstractIT() {
     @Test
     fun `Should respond to HEAD`() =
         runTest {
-            doTestCallMethod<TestPerson>(HttpMethod.Head) {
-                mokksy.head<TestPerson>(
+            doTestCallMethod(HttpMethod.Head) {
+                mokksy.head(
                     name,
                     TestPerson::class,
                     it,
@@ -213,7 +213,7 @@ internal class TypesafeMethodsIT : AbstractIT() {
                 """.trimIndent()
 
             mokksy
-                .post<Input>(name = "post", Input::class) {
+                .post(name = "post", Input::class) {
                     path = beEqual("/things")
                     bodyContains("$id")
                 }.respondsWith(String::class) {

--- a/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/jackson/JacksonSerializationIT.kt
+++ b/mokksy/src/jvmTest/kotlin/me/kpavlov/mokksy/jackson/JacksonSerializationIT.kt
@@ -47,7 +47,7 @@ internal class JacksonSerializationIT : AbstractIT() {
     fun `Should respond to POST with Jackson`() =
         runTest {
             mokksyWithJackson
-                .post<JacksonInput>(
+                .post(
                     requestType = JacksonInput::class,
                 ) {
                     path = beEqual("/jackson-$seed")


### PR DESCRIPTION
### Description

This pull request introduces the following changes:

- **Feature:** Added configurable default and per-request HTTP builders to `A2AClientFactory`, streamlining header and request-specific configurations.
- **Refactor:** Cleaned up code redundancies in `mokksy` and `A2AClient` for improved maintainability.
- **Documentation:** Enhanced the clarity and comprehensiveness of `A2AClient` API method documentation.
